### PR TITLE
`make setup` should also build Docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ blog:
 bundle:
 	docker-compose run ${RAILS_CONTAINER} bash -c 'cd /app && bundle'
 
-setup: db_create db_migrate
+setup: build db_create db_migrate
 
 publish: build
 	bin/publish


### PR DESCRIPTION
# Description of changes
By adding `build` functions to `make setup` Docker images will also be pulled and prepared locally, so that a new developer can be immediately productive.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #20 
