### PR TITLE
Feature/raise error on missing jwt secret - resolves issue 39

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem 'mocha'
   gem 'factory_girl_rails'
   gem 'faker'
+  gem 'awesome_print', '~> 1.8'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     airtable (0.0.9)
       httparty
     arel (7.1.4)
+    awesome_print (1.8.0)
     bcrypt (3.1.11)
     builder (3.2.3)
     byebug (9.0.6)
@@ -189,6 +190,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  awesome_print (~> 1.8)
   byebug
   devise
   factory_girl_rails

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -6,6 +6,9 @@ class JsonWebToken
     payload['exp'] = expiration.to_i.hours.from_now.to_i
 
     JWT.encode(payload, Rails.application.secrets.jwt_secret)
+  rescue => e
+    Rails.logger.debug "Failed to encode JsonWebToken due to: #{e}"
+    nil
   end
 
   def self.decode(token)

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -7,8 +7,7 @@ class JsonWebToken
 
     JWT.encode(payload, Rails.application.secrets.jwt_secret)
   rescue => e
-    Rails.logger.debug "Failed to encode JsonWebToken due to: #{e}"
-    nil
+    raise "Failed to encode JsonWebToken due to: #{e}"
   end
 
   def self.decode(token)


### PR DESCRIPTION
# Description of changes
#### Issue resolution
If `jwt_secret` is unavailable, the `rescue` block will capture the error, without halting the program.  	This implementation follows existing [precedence for capturing and logging errors for jwt_secret](https://github.com/OperationCode/operationcode_backend/blob/master/app/lib/json_web_token.rb#L15-L18).

Alternatively, we can be more aggressive, and `raise` an error, if that is the desired approach.  That will, however, halt the program, which might be what you are looking for here?

#### Development/Debugging gem
This PR also adds the Awesome Print gem for development and testing envs.  This speeds up my production when debugging and using the `rails console`, by increasing the readability of any code that is printed out.

It does so by providing structure and highlighting.

Ruby Gems link:  https://rubygems.org/gems/awesome_print

GitHub home page:  https://github.com/awesome-print/awesome_print

# Issue Resolved
Fixes #39  
