### PR TITLE
Fix Dev Bootcamp address - resolves issue #65

### DIFF
--- a/config/code_schools.yml
+++ b/config/code_schools.yml
@@ -48,11 +48,11 @@
       state: CA
       zip: 94107
     - va_accepted: false
-      address1: 351 West Hubbard Street (at Orleans)
-      address2: Suite 701
+      address1: 1033 W. Van Buren Street
+      address2: 3rd Floor
       city: Chicago
       state: IL
-      zip: 60605
+      zip: 60607
     - va_accepted: false
       address1: 48 Wall Street
       address2: 15th Floor


### PR DESCRIPTION
# Description of changes
Dev Bootcamp Chicago moved locations about 6 months ago. This change will reflect the most up-to-date address.

## Issue Resolved
Fixes #65 