### PR TITLE
fixed regex for email validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   after_create :welcome_user
   before_save :geocode, if: ->(v) { v.zip.present? && v.zip_changed? }
 
-  validates_format_of :email, :with => /@/
+  validates_format_of :email, :with => /\A.*@.*\z/
   validates :email, uniqueness: true
 
   has_many :requests


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
I changed the regex provided:   ` /@/`
To:     `/\A.*@.*\z/ `
A broader explanation of my regex is provided as follows:

`\A` : starts the string 
`.*`  : picks up any amount of any single character
`@`  : picks up the @ in the email
`.*` : picks up any amount of any single character
`\z `: ends the string


# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #47
