### PR TITLE
Feature/78 memberships by zip and total

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: run
 
 .PHONY: console-sandbox
 	console-sandbox:
-	 docker-compose run ${RAILS_CONTAINER} rails console --sandbox 
+	 docker-compose run ${RAILS_CONTAINER} rails console --sandbox
 
 .PHONY: run
 run:
@@ -38,7 +38,7 @@ db_migrate:
 .PHONY: test
 test: bg
 	docker-compose run operationcode-psql bash -c "while ! psql --host=operationcode-psql --username=postgres -c 'SELECT 1'; do sleep 5; done;"
-	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && rake db:test:prepare && rake db:seed && rake test'
+	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && rake db:test:prepare && rake test'
 
 .PHONY: bundle
 bundle:

--- a/apiary.apib
+++ b/apiary.apib
@@ -369,6 +369,90 @@ API endpoints that Operation Code's Rails backend makes available to its React f
             errors: "Some error message"
         }
 
+## User | Count By Location [/api/v1/users/by_location{?zip,city,lat_long,radius}]
+
+### By Location [GET]
+
++ Parameters
+
+    + zip (string, optional) - String of comma-separated zip code(s), i.e. '80126', or '80126, 80203'
+    + city (string, optional) - A string of a 'City, State, County' (i.e. 'Denver, CO, US')
+    + lat_long (integer, optional) - Comma-separated integer latitude and longitude, i.e. 30.285648, -97.742052
+    + radius (integer, optional) - Includes results within the radius' distance from the location, in miles.  Works in conjunction with city or lat_long, not zip code. Defaults to 20 miles, if not supplied.
+
++ Request (application/json)
+
+    + Headers
+
+            Authorization: Bearer Access-Token
+
+
+    + Body
+
+            {
+                zip: '80126, 80203'
+            }
+
+            /*or*/
+
+            {
+                city: 'Denver, CO, US'
+            }
+
+            /*or*/
+
+            {
+                city: 'Denver, CO, US',
+                radius: 30
+            }
+
+            /*or*/
+
+            {
+                lat_long: 30.285648, -97.742052
+            }
+
+            /*or*/
+
+            {
+                lat_long: 30.285648, -97.742052,
+                radius: 30
+            }
+
++ Response 200 (application/json)
+
+        {
+            user_count: 2
+        }
+
++ Response 422 (application/json)
+
+        {
+            errors: "Some error message"
+        }
+
+## User | Total Count [/api/v1/users]
+
+### Total User Count [GET]
+
++ Request (application/json)
+
+    + Headers
+
+            Authorization: Bearer Access-Token
+
++ Response 200 (application/json)
+
+        {
+            user_count: 2
+        }
+
++ Response 422 (application/json)
+
+        {
+            errors: "Some error message"
+        }
+
 ## Vote | Create [/api/v1/resources/{resource_id}/votes{?user_id}]
 
 + Parameters

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -34,7 +34,7 @@ module Api
       end
 
       def by_location
-        render json: { user_count: user_count }, status: :ok
+        render json: { user_count: UsersByLocation.new(params).count }, status: :ok
       rescue StandardError => e
         render json: { errors: e.message }, status: :unprocessable_entity
       end
@@ -43,22 +43,6 @@ module Api
 
       def user_params
         params.require(:user).permit(:email, :zip, :password, :first_name, :last_name, :mentor, :slack_name, :verified)
-      end
-
-      def radius
-        params[:radius] || 20
-      end
-
-      def user_count
-        if params[:zip].present?
-          User.count_by_zip(params[:zip])
-        elsif params[:city].present?
-          User.count_by_location(params[:city], radius)
-        elsif params[:coordinates].present?
-          User.count_by_location(params[:coordinates], radius)
-        else
-          raise 'A city, zip code, or coordinates must be provided'
-        end
       end
     end
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -33,12 +33,33 @@ module Api
         render json: { status: :unprocessable_entity }, status: :unprocessable_entity
       end
 
-    private
+      def by_location
+        render json: { user_count: user_count }, status: :ok
+      rescue StandardError => e
+        render json: { errors: e.message }, status: :unprocessable_entity
+      end
+
+      private
 
       def user_params
         params.require(:user).permit(:email, :zip, :password, :first_name, :last_name, :mentor, :slack_name, :verified)
       end
 
+      def radius
+        params[:radius] || 20
+      end
+
+      def user_count
+        if params[:zip].present?
+          User.count_by_zip(params[:zip])
+        elsif params[:city].present?
+          User.count_by_location(params[:city], radius)
+        elsif params[:coordinates].present?
+          User.count_by_location(params[:coordinates], radius)
+        else
+          raise 'A city, zip code, or coordinates must be provided'
+        end
+      end
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,13 @@
 module Api
   module V1
     class UsersController < ApplicationController
+      before_action :authenticate_user!, except: [:create, :verify]
+
+      def index
+        render json: { user_count: User.count }, status: :ok
+      rescue StandardError => e
+        render json: { errors: e.message }, status: :unprocessable_entity
+      end
 
       def create
         user = User.new(user_params)

--- a/app/lib/users_by_location.rb
+++ b/app/lib/users_by_location.rb
@@ -1,0 +1,20 @@
+class UsersByLocation
+  def initialize(params)
+    @zip = params[:zip]
+    @city = params[:city]
+    @lat_long = params[:lat_long]
+    @radius = params[:radius] || 20
+  end
+
+  def count
+    if @zip.present?
+      User.count_by_zip @zip
+    elsif @city.present?
+      User.count_by_location @city, @radius
+    elsif @lat_long.present?
+      User.count_by_location @lat_long, @radius
+    else
+      raise 'A city, zip code, or latitude/longitude must be provided'
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,20 @@ class User < ApplicationRecord
   has_many :votes
 
   scope :mentors, -> { where(mentor: true) }
+  scope :by_zip, ->(zip) { where(zip: zip) }
+
+  # Returns a count of all users with the passed in zip code(s)
+  #
+  # @param zip_codes [String] String of comma-separated zip code(s), i.e. '80126', or '80126, 80203'
+  #
+  def self.count_by_zip(zip_codes)
+    return 0 unless zip_codes.present?
+
+    zips = zip_codes.split(',').map(&:strip)
+
+    by_zip(zips).count
+  end
+
 
   def welcome_user
     invite_to_slack

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,17 @@ class User < ApplicationRecord
     by_zip(zips).count
   end
 
+  # Returns a count of all users within the passed in location.  The location can
+  # be either a city, or a set of coordinates.
+  #
+  # @param location [String || Array] Either a 'City, State, County' or [Latitude, Longitude]
+  #   For example, 'Denver, CO, US'.
+  # @param radius [Integer] Include results within the radius' distance from the location, in miles.
+  # @see https://github.com/alexreisner/geocoder#for-activerecord-models
+  #
+  def self.count_by_location(location, radius=20)
+    near(location, radius.to_i)&.size
+  end
 
   def welcome_user
     invite_to_slack

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   end
 
   # Returns a count of all users within the passed in location.  The location can
-  # be either a city, or a set of coordinates.
+  # be either a city, or a set of latitude/longitude.
   #
   # @param location [String || Array] Either a 'City, State, County' or [Latitude, Longitude]
   #   For example, 'Denver, CO, US'.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       get '/status/protected', to: 'status#protected'
 
       post '/users/profile/verify', to: 'users#verify'
+      get '/users/by_location', to: 'users#by_location'
 
       resources :code_schools, only: :index
       resources :events, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,6 @@ Rails.application.routes.draw do
       get '/status', to: 'status#all'
       get '/status/protected', to: 'status#protected'
 
-      post '/users', to: 'users#create'
       post '/users/profile/verify', to: 'users#verify'
 
       resources :code_schools, only: :index
@@ -26,6 +25,7 @@ Rails.application.routes.draw do
       end
       resources :tags, only: :index
       resources :team_members, only: [:index, :create, :update, :destroy]
+      resources :users, only: [:index, :create]
 
       devise_scope :user do
         post '/sessions', to: 'sessions#create'

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    user = create(:user)
+    @headers = authorization_headers(user)
+  end
+
+  test ":index returns User.count" do
+    2.times { create :user }
+
+    get api_v1_users_url, headers: @headers, as: :json
+
+    assert_equal({ 'user_count' => 3 }, response.parsed_body)
+    assert_equal 200, response.status
+  end
+
+  test ":by_location returns User.count of users located in the passed in location" do
+    create :user, zip: '80238', latitude: 39.762920, longitude: -104.872770
+    create :user, zip: '80202', latitude: 39.745211, longitude: -104.991638
+
+    assert_equal User.count, 3
+
+    params = { zip: '80238' }
+    get api_v1_users_by_location_url(params), headers: @headers, as: :json
+    assert_equal({ 'user_count' => 1 }, response.parsed_body)
+    assert_equal 200, response.status
+
+    params = { zip: '80238, 80202' }
+    get api_v1_users_by_location_url(params), headers: @headers, as: :json
+    assert_equal({ 'user_count' => 2 }, response.parsed_body)
+
+    params = { city: 'Denver, CO, US' }
+    get api_v1_users_by_location_url(params), headers: @headers, as: :json
+    assert_equal({ 'user_count' => 2 }, response.parsed_body)
+
+    params = { coordinates: [39.762920, -104.872770] }
+    get api_v1_users_by_location_url(params), headers: @headers, as: :json
+    assert_equal({ 'user_count' => 2 }, response.parsed_body)
+
+    params = { coordinates: [39.762920, -104.872770], radius: 2 }
+    get api_v1_users_by_location_url(params), headers: @headers, as: :json
+    assert_equal({ 'user_count' => 1 }, response.parsed_body)
+  end
+end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -28,15 +28,11 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)
 
-    params = { city: 'Austin, TX, US' }
+    params = { lat_long: [30.285648, -97.742052] }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)
 
-    params = { coordinates: [30.285648, -97.742052] }
-    get api_v1_users_by_location_url(params), headers: @headers, as: :json
-    assert_equal({ 'user_count' => 2 }, response.parsed_body)
-
-    params = { coordinates: [30.285648, -97.742052], radius: 2 }
+    params = { lat_long: [30.285648, -97.742052], radius: 2 }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 1 }, response.parsed_body)
   end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
   setup do
-    User.destroy_all
     user = create(:user)
     @headers = authorization_headers(user)
   end
@@ -12,34 +11,32 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
 
     get api_v1_users_url, headers: @headers, as: :json
 
-    assert_equal({ 'user_count' => 3 }, response.parsed_body)
+    assert_equal({ 'user_count' => User.count }, response.parsed_body)
     assert_equal 200, response.status
   end
 
   test ":by_location returns User.count of users located in the passed in location" do
-    create :user, zip: '80238', latitude: 39.762920, longitude: -104.872770
-    create :user, zip: '80202', latitude: 39.745211, longitude: -104.991638
+    create :user, zip: '78705', latitude: 30.285648, longitude: -97.742052
+    create :user, zip: '78756', latitude: 30.312601, longitude: -97.738591
 
-    assert_equal User.count, 3
-
-    params = { zip: '80238' }
+    params = { zip: '78705' }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 1 }, response.parsed_body)
     assert_equal 200, response.status
 
-    params = { zip: '80238, 80202' }
+    params = { zip: '78705, 78756' }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)
 
-    params = { city: 'Denver, CO, US' }
+    params = { city: 'Austin, TX, US' }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)
 
-    params = { coordinates: [39.762920, -104.872770] }
+    params = { coordinates: [30.285648, -97.742052] }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)
 
-    params = { coordinates: [39.762920, -104.872770], radius: 2 }
+    params = { coordinates: [30.285648, -97.742052], radius: 2 }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 1 }, response.parsed_body)
   end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -31,10 +31,6 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)
 
-    params = { city: 'Austin, TX, US' }
-    get api_v1_users_by_location_url(params), headers: @headers, as: :json
-    assert_equal({ 'user_count' => 2 }, response.parsed_body)
-
     params = { lat_long: [30.285648, -97.742052] }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
   setup do
+    User.destroy_all
     user = create(:user)
     @headers = authorization_headers(user)
   end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -28,6 +28,10 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)
 
+    params = { city: 'Austin, TX, US' }
+    get api_v1_users_by_location_url(params), headers: @headers, as: :json
+    assert_equal({ 'user_count' => 2 }, response.parsed_body)
+
     params = { lat_long: [30.285648, -97.742052] }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -16,8 +16,11 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test ":by_location returns User.count of users located in the passed in location" do
-    create :user, zip: '78705', latitude: 30.285648, longitude: -97.742052
-    create :user, zip: '78756', latitude: 30.312601, longitude: -97.738591
+    tom = create :user, zip: '78705'
+    sam = create :user, zip: '78756'
+
+    tom.update latitude: 30.285648, longitude: -97.742052
+    sam.update latitude: 30.312601, longitude: -97.738591
 
     params = { zip: '78705' }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
@@ -36,7 +39,7 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)
 
-    params = { lat_long: [30.285648, -97.742052], radius: 2 }
+    params = { lat_long: [30.285648, -97.742052], radius: 1 }
     get api_v1_users_by_location_url(params), headers: @headers, as: :json
     assert_equal({ 'user_count' => 1 }, response.parsed_body)
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -101,7 +101,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 0, results
   end
 
-  test '.count_by_location returns a count of all users within the passed in city, or coordinates, and radius from that location' do
+  test '.count_by_location returns a count of all users within the passed in city, or latitude/longitude, and radius from that location' do
     tom = create :user, zip: '78705'
     sam = create :user, zip: '78756'
     bob = create :user, zip: '83704'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -101,4 +101,21 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 0, results
   end
 
+  test '.count_by_location returns a count of all users within the passed in city, or coordinates, and radius from that location' do
+    tom = create :user, zip: '80238'
+    sam = create :user, zip: '80202'
+    bob = create :user, zip: '10004'
+
+    tom.update latitude: 39.762920, longitude: -104.872770
+    sam.update latitude: 39.745211, longitude: -104.991638
+
+    results = User.count_by_location [39.762920, -104.872770]
+    assert_equal 2, results
+
+    results = User.count_by_location [40.704540, -74.013087]
+    assert_equal 1, results
+
+    results = User.count_by_location ''
+    assert_equal 0, results
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -102,17 +102,18 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test '.count_by_location returns a count of all users within the passed in city, or coordinates, and radius from that location' do
-    tom = create :user, zip: '80238'
-    sam = create :user, zip: '80202'
-    bob = create :user, zip: '10004'
+    tom = create :user, zip: '78705'
+    sam = create :user, zip: '78756'
+    bob = create :user, zip: '83704'
 
-    tom.update latitude: 39.762920, longitude: -104.872770
-    sam.update latitude: 39.745211, longitude: -104.991638
+    tom.update latitude: 30.285648, longitude: -97.742052
+    sam.update latitude: 30.312601, longitude: -97.738591
+    bob.update latitude: 43.606690, longitude: -116.282246
 
-    results = User.count_by_location [39.762920, -104.872770]
+    results = User.count_by_location [30.285648, -97.742052]
     assert_equal 2, results
 
-    results = User.count_by_location [40.704540, -74.013087]
+    results = User.count_by_location [43.606690, -116.282246]
     assert_equal 1, results
 
     results = User.count_by_location ''

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -85,4 +85,20 @@ class UserTest < ActiveSupport::TestCase
       ]
     )
   end
+
+  test '.count_by_zip returns a count of all users within the passed in zip code(s)' do
+    tom = create :user, zip: '80112'
+    sam = create :user, zip: '80126'
+    bob = create :user, zip: '80126'
+
+    results = User.count_by_zip '80126'
+    assert_equal 2, results
+
+    results = User.count_by_zip '80126, 80112'
+    assert_equal 3, results
+
+    results = User.count_by_zip ''
+    assert_equal 0, results
+  end
+
 end


### PR DESCRIPTION
# Description of changes
Creates API endpoints for retrieving various `User` counts.  Specifically:

- an `:index` endpoint to retrieve total `User` count
- a `:by_location` endpoint to retrieve `User` count by either:
  - zip code
  - city
  - latitude/longitude
- Test coverage
- Apiary API documentation

# Issue Resolved
Fixes #78 
