### PR TITLE
Working links to fragments in the contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ So, you want to learn how to program? Contributing to Operation Code is a great 
 2. [Setting Up Your Environment](#setting-up-your-environment)
 3. [Finding an Issue](#finding-an-issue)
 4. [Working on Your Issue](#working-on-your-issue)
-5. [Submitting Your Changes](#pull-request-guidelines)
+5. [Submitting Your Changes](#submitting-your-changes)
 
 ## Quickstart
 1. [Setting Up Your Environment](#setting-up-your-environment)
@@ -107,7 +107,7 @@ So, you want to learn how to program? Contributing to Operation Code is a great 
   git checkout master
   ```
 
-## Pull Request Guidelines; Submitting Your Changes
+## Submitting Your Changes
 * When you have completed work on your feature branch, you are ready to submit a [pull request](https://help.github.com/articles/using-pull-requests/).
 
 * Each pull request should:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ So, you want to learn how to program? Contributing to Operation Code is a great 
 1. [Quickstart](#quickstart)
 2. [Setting Up Your Environment](#setting-up-your-environment)
 3. [Finding an Issue](#finding-an-issue)
-4. [Working on Your Issue](#getting-the-code)
+4. [Working on Your Issue](#working-on-your-issue)
 5. [Submitting Your Changes](#submitting-your-changes)
 
 ## Quickstart

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ So, you want to learn how to program? Contributing to Operation Code is a great 
 2. [Setting Up Your Environment](#setting-up-your-environment)
 3. [Finding an Issue](#finding-an-issue)
 4. [Working on Your Issue](#working-on-your-issue)
-5. [Submitting Your Changes](#submitting-your-changes)
+5. [Submitting Your Changes](#pull-request-guidelines;%20submitting-your-changes)
 
 ## Quickstart
 1. [Setting Up Your Environment](#setting-up-your-environment)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ So, you want to learn how to program? Contributing to Operation Code is a great 
 2. [Setting Up Your Environment](#setting-up-your-environment)
 3. [Finding an Issue](#finding-an-issue)
 4. [Working on Your Issue](#working-on-your-issue)
-5. [Submitting Your Changes](#pull-request-guidelines;%20submitting-your-changes)
+5. [Submitting Your Changes](#pull-request-guidelines)
 
 ## Quickstart
 1. [Setting Up Your Environment](#setting-up-your-environment)


### PR DESCRIPTION
# Description of changes
This corrects the Markdown used to point to sections within the contribution guide

# Issue Resolved
Fixes #81
