### PR TITLE
feature/51-send-email-with-sendgrid-template

### DIFF
--- a/app/lib/send_grid_client.rb
+++ b/app/lib/send_grid_client.rb
@@ -17,6 +17,52 @@ class SendGridClient
     Rails.logger.error e.backtrace.join("\n")
   end
 
+  # Sends a transactional email with a template, based on the passed in options hash.
+  #
+  # @param options [Hash] Sample options hash:
+  #   {
+  #     to: 'tom@gmail.com',
+  #     from: 'frank@oc.com',
+  #     subject: 'Hello',
+  #     user_count: 5,
+  #     body: 'Hello world!',
+  #     template_id: 'asdfas-123123-asdfasf-2qwerqwe'
+  #   }
+  # @return [SendGrid::Response] Includes a body and status_code
+  # @see https://github.com/sendgrid/sendgrid-ruby/blob/7c8973f7b8de51a98dce73a52138791b19434573/USE_CASES.md#with-mail-helper-class
+  #
+  def send_email_with_template(options={})
+    Rails.logger.info("Sending email to #{options[:to]} at #{Time.current} re: #{options[:subject]}")
+
+    mail = {
+      "personalizations" => [
+        {
+          "to" => [
+            {
+              "email" => options[:to]
+            }
+          ],
+          "subject" => options[:subject],
+          "template_id" => options[:transactional_template_id]
+        }
+      ],
+      "from" => {
+        "email" => options[:from]
+      },
+      "content" => [
+        {
+          "type" => "text/plain",
+          "value" => options[:body]
+        }
+      ]
+    }
+
+    @sendgrid.client.mail._("send").post(request_body: mail)
+  rescue => e
+    Rails.logger.error "Failed to send email to #{options[:to]} re: #{options[:subject]} due to: #{e}"
+    Rails.logger.error e.backtrace.join("\n")
+  end
+
   private
 
   def add_recipient(data)

--- a/app/lib/send_grid_client.rb
+++ b/app/lib/send_grid_client.rb
@@ -61,6 +61,7 @@ class SendGridClient
   rescue => e
     Rails.logger.error "Failed to send email to #{options[:to]} re: #{options[:subject]} due to: #{e}"
     Rails.logger.error e.backtrace.join("\n")
+    raise "Failed to send email to #{options[:to]} re: #{options[:subject]} due to: #{e}"
   end
 
   private

--- a/app/lib/send_grid_client.rb
+++ b/app/lib/send_grid_client.rb
@@ -44,7 +44,7 @@ class SendGridClient
           ],
           "subject" => options[:subject],
           "substitutions" => {
-            "-user_count-" => options[:user_count]
+            "-user_count-" => options[:user_count].to_s
           },
           "template_id" => options[:transactional_template_id]
         }

--- a/app/lib/send_grid_client.rb
+++ b/app/lib/send_grid_client.rb
@@ -24,7 +24,7 @@ class SendGridClient
   #     to: 'tom@gmail.com',
   #     from: 'frank@oc.com',
   #     subject: 'Hello',
-  #     user_count: 5,
+  #     user_count: '5',
   #     body: 'Hello world!',
   #     template_id: 'asdfas-123123-asdfasf-2qwerqwe'
   #   }
@@ -43,6 +43,9 @@ class SendGridClient
             }
           ],
           "subject" => options[:subject],
+          "substitutions" => {
+            "-user_count-" => options[:user_count]
+          },
           "template_id" => options[:transactional_template_id]
         }
       ],


### PR DESCRIPTION
# Description of changes
Creates a new method for the SendGridClient that sends a transactional email using sendgrid-ruby. This method takes a transactional_template_id and a hash of values that can be substituted into the template.

# Issue Resolved
Fixes #51 