### PR TITLE
Feature/105 save users state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ db_create:
 db_migrate:
 	docker-compose run ${RAILS_CONTAINER} rake db:migrate
 
+.PHONY: db_rollback
+db_rollback:
+	docker-compose run ${RAILS_CONTAINER} rake db:rollback
+
 .PHONY: test
 test: bg
 	docker-compose run operationcode-psql bash -c "while ! psql --host=operationcode-psql --username=postgres -c 'SELECT 1'; do sleep 5; done;"

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -42,7 +42,7 @@ module Api
       private
 
       def user_params
-        params.require(:user).permit(:email, :zip, :password, :first_name, :last_name, :mentor, :slack_name, :verified)
+        params.require(:user).permit(:email, :zip, :password, :first_name, :last_name, :mentor, :slack_name, :verified, :state)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   geocoded_by :zip do |user, results|
-    if geocoded_object = results.first
+    geocoded_object = results.first
+
+    if geocoded_object.present?
       user.latitude  = geocoded_object.latitude
       user.longitude = geocoded_object.longitude
       user.state     = geocoded_object.state_code

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,14 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  geocoded_by :zip
+
+  geocoded_by :zip do |user, results|
+    if geocoded_object = results.first
+      user.latitude  = geocoded_object.latitude
+      user.longitude = geocoded_object.longitude
+      user.state     = geocoded_object.state_code
+    end
+  end
 
   # These attributes are what we send to sendgrid as custom fields
   SENDGRID_ATTRIBUTES = %w[first_name last_name email]

--- a/db/migrate/20170720215043_add_state_to_user.rb
+++ b/db/migrate/20170720215043_add_state_to_user.rb
@@ -1,0 +1,5 @@
+class AddStateToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170701194821) do
+ActiveRecord::Schema.define(version: 20170720215043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 20170701194821) do
     t.string   "timezone"
     t.text     "bio"
     t.boolean  "verified",               default: false, null: false
+    t.string   "state"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -18,6 +18,8 @@ namespace :users do
         begin
           results = Geocoder.search([user.latitude, user.longitude]).try(:first)
 
+          raise "Could not geocode User id #{user.id}" unless results.present?
+
           user.update! state: results.state_code
         rescue => e
           p "When adding the :state for User id #{user.id}, experienced this error: #{e}"

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,34 @@
+namespace :users do
+  desc "Sets the user's :state based on user's :zip, for any any where user.state == nil"
+  task populate_states: :environment do
+    # https://developers.google.com/maps/documentation/geocoding/usage-limits
+    GEOCODING_DAILY_MAX = 2500
+    GEOCODING_PER_S_MAX = 50
+
+    users = User.where.not(latitude: nil, longitude: nil).where(state: nil).limit(GEOCODING_DAILY_MAX)
+    user_count = users.count
+
+    return "0 eligible users to be updated" unless users.present?
+    p "#{user_count} users are eligible to be updated."
+
+    users.in_batches(of: GEOCODING_PER_S_MAX).each_with_index do |batch, batch_index|
+      batch.each_with_index do |user, index|
+        p "Updating #{(batch_index * GEOCODING_PER_S_MAX) + index + 1} of #{user_count}"
+
+        begin
+          results = Geocoder.search([user.latitude, user.longitude]).try(:first)
+
+          user.update! state: results.state_code
+        rescue => e
+          p "When adding the :state for User id #{user.id}, experienced this error: #{e}"
+          Rails.logger.info "When adding the :state for User id #{user.id}, experienced this error: #{e}"
+        end
+      end
+
+      sleep 2
+    end
+
+    remaining = User.where.not(latitude: nil, longitude: nil).where(state: nil).count
+    p "#{remaining} users left to be updated.  Task can be reran in 24 hours."
+  end
+end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
     timezone 'EST'
     mentor false
     verified false
+    state { Faker::Address.state_abbr }
 
     factory :mentor do
       mentor true

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -41,6 +41,7 @@ class UserTest < ActiveSupport::TestCase
     u.update_attributes(zip: '80203')
     assert_equal 20.7143528, u.latitude
     assert_equal -174.0059731, u.longitude
+    assert_equal 'CO', u.state
   end
 
   test 'only geocodes if zip is updated' do


### PR DESCRIPTION
# Description of changes
Saves the state the `User` lives in, to their db record.  Specifically:

- Adds a new attribute to the `User` model called `:state`
- Extends the `before_save` filter to save the user's `:state` abbreviation into the new attribute
- Rake task to populate all existing users `:state`, if their latitude and longitude exists
- Rake task accounts for Google geocoding API  rate limits 

# Issue Resolved
Fixes #105 
