### PR TITLE
Bug/103 users by location not authenticating

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -382,11 +382,6 @@ API endpoints that Operation Code's Rails backend makes available to its React f
 
 + Request (application/json)
 
-    + Headers
-
-            Authorization: Bearer Access-Token
-
-
     + Body
 
             {
@@ -436,10 +431,6 @@ API endpoints that Operation Code's Rails backend makes available to its React f
 ### Total User Count [GET]
 
 + Request (application/json)
-
-    + Headers
-
-            Authorization: Bearer Access-Token
 
 + Response 200 (application/json)
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V1
     class UsersController < ApplicationController
-      before_action :authenticate_user!, except: [:create, :verify]
-
       def index
         render json: { user_count: User.count }, status: :ok
       rescue StandardError => e

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -1,15 +1,10 @@
 require 'test_helper'
 
 class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
-  setup do
-    user = create(:user)
-    @headers = authorization_headers(user)
-  end
-
   test ":index returns User.count" do
     2.times { create :user }
 
-    get api_v1_users_url, headers: @headers, as: :json
+    get api_v1_users_url, as: :json
 
     assert_equal({ 'user_count' => User.count }, response.parsed_body)
     assert_equal 200, response.status
@@ -23,20 +18,20 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
     sam.update latitude: 30.312601, longitude: -97.738591
 
     params = { zip: '78705' }
-    get api_v1_users_by_location_url(params), headers: @headers, as: :json
+    get api_v1_users_by_location_url(params), as: :json
     assert_equal({ 'user_count' => 1 }, response.parsed_body)
     assert_equal 200, response.status
 
     params = { zip: '78705, 78756' }
-    get api_v1_users_by_location_url(params), headers: @headers, as: :json
+    get api_v1_users_by_location_url(params), as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)
 
     params = { lat_long: [30.285648, -97.742052] }
-    get api_v1_users_by_location_url(params), headers: @headers, as: :json
+    get api_v1_users_by_location_url(params), as: :json
     assert_equal({ 'user_count' => 2 }, response.parsed_body)
 
     params = { lat_long: [30.285648, -97.742052], radius: 1 }
-    get api_v1_users_by_location_url(params), headers: @headers, as: :json
+    get api_v1_users_by_location_url(params), as: :json
     assert_equal({ 'user_count' => 1 }, response.parsed_body)
   end
 end


### PR DESCRIPTION
# Description of changes
Removes the requirement for authentication when accessing the `/api/v1/users/by_location` endpoint.

Updates the tests and API documentation accordingly.

# Issue Resolved
Fixes #103 
