### PR TITLE
Feature/102 slack inviter job endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -210,7 +210,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
             errors: "Some error message"
         }
 
-## Slack | Invite [/api/v1/slack]
+## Slack User | Invite [/api/v1/slack_users]
 
 ### Invite a User to Slack [POST]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -210,6 +210,30 @@ API endpoints that Operation Code's Rails backend makes available to its React f
             errors: "Some error message"
         }
 
+## Slack | Invite [/api/v1/slack]
+
+### Invite a User to Slack [POST]
+
++ Request (application/json)
+
+    + Headers
+
+            Authorization: Bearer Access-Token
+
++ Response 200 (application/json)
+
+    + Body
+
+            {
+                status: 200
+            }
+
++ Response 422 (application/json)
+
+        {
+            errors: "Some error message"
+        }
+
 ## Tag | Collection [/api/v1/tags]
 
 ### List All Tags [GET]

--- a/app/controllers/api/v1/slack_users_controller.rb
+++ b/app/controllers/api/v1/slack_users_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class SlacksController < ApplicationController
+    class SlackUsersController < ApplicationController
       before_action :authenticate_user!
 
       def create

--- a/app/controllers/api/v1/slacks_controller.rb
+++ b/app/controllers/api/v1/slacks_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    class SlacksController < ApplicationController
+      before_action :authenticate_user!
+
+      def create
+        raise "User id #{current_user.id} does not have a saved email address." unless current_user.email.present?
+
+        SlackJobs::InviterJob.perform_now current_user.email
+
+        render json: { status: :ok }
+      rescue StandardError => e
+        render json: { errors: e.message }, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
         resources :votes, only: [:create, :destroy]
       end
       resources :services, only: :index
-      resources :slacks, only: :create, path: 'slack'
+      resources :slack_users, only: :create
       resources :squads, only: [:index, :create, :show] do
         member do
           post 'join'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
       get '/status', to: 'status#all'
       get '/status/protected', to: 'status#protected'
 
-      post '/users/profile/verify', to: 'users#verify'
       get '/users/by_location', to: 'users#by_location'
+      post '/users/profile/verify', to: 'users#verify'
 
       resources :code_schools, only: :index
       resources :events, only: :index
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
         resources :votes, only: [:create, :destroy]
       end
       resources :services, only: :index
+      resources :slacks, only: :create, path: 'slack'
       resources :squads, only: [:index, :create, :show] do
         member do
           post 'join'


### PR DESCRIPTION
# Description of changes
Adds a new endpoint that, when called, invites the `current_user` to slack via the `SlackJobs::InviterJob.perform` job.  

New endpoint requires authorization.

# Issue Resolved
Fixes #102 
