### PR TITLE
Feature/113 password reset endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -457,6 +457,36 @@ API endpoints that Operation Code's Rails backend makes available to its React f
             errors: "Some error message"
         }
 
+## User | Reset Password [/api/v1/users/passwords/reset{?email}]
+
++ Parameters
+
+    + email (string, required) - The email address of the requesting User
+
+### Reset the User's Password  [POST]
+
++ Request (application/json)
+
+    + Body
+
+            {
+                "email": "frank@example.com"
+            }
+
++ Response 200 (application/json)
+
+    + Body
+
+            {
+                status: 200
+            }
+
++ Response 422 (application/json)
+
+        {
+            errors: "Some error message"
+        }
+
 ## User | Total Count [/api/v1/users]
 
 ### Total User Count [GET]

--- a/app/controllers/api/v1/users/passwords_controller.rb
+++ b/app/controllers/api/v1/users/passwords_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V1
+    module Users
+      class PasswordsController < ApplicationController
+
+        # Resets password token and sends reset password instructions by email.
+        #
+        # @see http://www.rubydoc.info/github/plataformatec/devise/master/Devise/Models/Recoverable
+        #
+        def reset
+          user = User.find_by email: params[:email]
+
+          raise "Could not find a user with that email address" unless user.present?
+          user.send_reset_password_instructions
+
+          render json: { status: :ok }
+        rescue StandardError => e
+          render json: { errors: e.message }, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,10 @@ Rails.application.routes.draw do
       devise_scope :user do
         post '/sessions', to: 'sessions#create'
       end
+
+      namespace :users do
+        post '/passwords/reset', to: 'passwords#reset'
+      end
     end
   end
 end


### PR DESCRIPTION
# Description of changes
Endpoint to reset a user's password.  Specifically:
- Adds a new `/api/v1/users/passwords/reset` endpoint that takes an email address
- Updates apiary documentation

The new endpoint:
> [Resets password token and send reset password instructions by email.](http://www.rubydoc.info/github/plataformatec/devise/master/Devise/Models/Recoverable) 

# Issue Resolved
Fixes #113 
