### PR TITLE
Set ENV_VAR for SLACK_SUBDOMAIN

### DIFF
--- a/run/secrets/slack_subdomain
+++ b/run/secrets/slack_subdomain
@@ -1,1 +1,1 @@
-fake_subdomain
+operation-code


### PR DESCRIPTION
When standing up the backend, redis reports that the `SLACK_SUBDOMAIN` is not set.

# Description of changes
<!-- What does this PR change and why -->

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #128
