### PR TITLE
Remove Dev Bootcamp from code_schools.yml

### DIFF
--- a/config/code_schools.yml
+++ b/config/code_schools.yml
@@ -47,33 +47,6 @@
       state: TN
       zip: 37210
 
-- name: Dev Bootcamp
-  url: http://devbootcamp.com
-  logo: https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/dev_bootcamp.jpg
-  full_time: true
-  hardware_included: false
-  has_online: false
-  online_only: false
-  locations:
-    - va_accepted: false
-      address1: 633 Folsom Street (at Hawthorne)
-      address2: 6th Floor
-      city: San Francisco
-      state: CA
-      zip: 94107
-    - va_accepted: false
-      address1: 1033 W. Van Buren Street
-      address2: 3rd Floor
-      city: Chicago
-      state: IL
-      zip: 60607
-    - va_accepted: false
-      address1: 48 Wall Street
-      address2: 15th Floor
-      city: New York
-      state: NY
-      zip: 10005
-
 - name: Galvanize
   url: https://new.galvanize.com
   logo: https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/galvanize.jpg


### PR DESCRIPTION
# Description of changes
Removes Dev Bootcamp from code_schools.yml, since Dev Bootcamp has shut down.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #107 

I didn't create a test since it didn't seem appropriate for this particular issue. I wanted to visually test it, but I wasn't sure how exactly to do that with the frontend and backend projects split. I'm able to get the Ruby on Rails home screen up when I run `make` - is there a way to connect up the front end so that I can see changes I make? I have the frontend project set up locally as well.