### PR TITLE
Feature/118 emails downcased

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   after_create :welcome_user
   before_save :geocode, if: ->(v) { v.zip.present? && v.zip_changed? }
   before_save :upcase_state
+  before_save :downcase_email
 
   validates_format_of :email, :with => /\A.*@.*\z/
   validates :email, uniqueness: true
@@ -102,5 +103,9 @@ class User < ApplicationRecord
 
   def upcase_state
    state.upcase! if state
+  end
+
+  def downcase_email
+    email.downcase! if email
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -26,6 +26,12 @@ class UserTest < ActiveSupport::TestCase
     refute User.new(email: test_email).valid?
   end
 
+  test 'email must be saved downcased' do
+    new_email = 'NEW_EMAIL@exaMple.cOm'
+    assert create(:user, email: new_email.downcase)
+    refute User.new(email: new_email).valid?
+  end
+
   test 'doesnt geocode until we save' do
     u = build(:user, latitude: nil, longitude: nil)
     assert u.valid?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -26,10 +26,15 @@ class UserTest < ActiveSupport::TestCase
     refute User.new(email: test_email).valid?
   end
 
-  test 'email must be saved downcased' do
-    new_email = 'NEW_EMAIL@exaMple.cOm'
-    assert create(:user, email: new_email.downcase)
-    refute User.new(email: new_email).valid?
+  test 'email is downcased on create' do
+    u = create(:user, email: 'NEW_EMAIL@exaMple.cOm')
+    assert_equal 'new_email@example.com', u.email
+  end
+
+  test 'email is downcased after update' do
+    u = create(:user, email: 'UPDATE_EMAIL@exaMple.cOm')
+    u.update!(email: 'UPDATE_EMAIL@exaMple.cOm')
+    assert_equal 'update_email@example.com', u.email
   end
 
   test 'doesnt geocode until we save' do


### PR DESCRIPTION
# Description of changes
 Emails should be stored in all lowercase into the database 

# Issue Resolved
 Issue #118 Emails should be downcased using `before_save` within the `User` model and tested within the`user_test.rb`
