### PR TITLE
RE #123 added 'Operation Code' to subject for password reset and Devi…

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'staff@operationcode.org'
+  config.mailer_sender = '"Operation Code" <staff@operationcode.org>'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -20,7 +20,7 @@ en:
       confirmation_instructions:
         subject: "Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "Operation Code - Reset password instructions"
       unlock_instructions:
         subject: "Unlock instructions"
       email_changed:


### PR DESCRIPTION
Skaggs

# Description of changes
Updated the Devise Password Reset Subject to include "Operation Code" and added the "Operation Code" name to the Devise emails.

# Issue Resolved
Fixes #123  - Password reset email should say "Operation Code" somewhere in the subject/From

# Notes
Should probably add some tests for the mailers, but maybe that's another ticket.