### PR TITLE
Update information for Turing School of Software and Design

### DIFF
--- a/config/code_schools.yml
+++ b/config/code_schools.yml
@@ -119,9 +119,10 @@
   url: http://turing.io/
   logo: https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/turing.jpg
   full_time: true
-  hardware_included: false
+  hardware_included: true
   has_online: false
   online_only: false
+  notes: <strong> Turing offers two diversity scholarships each cohort that veterans are eligible to apply for. This funding will be used as tuition credit to offset tuition costs. </strong>
   locations:
     - va_accepted: true
       address1: 1510 Blake Street


### PR DESCRIPTION
Added the information about the $4,000 scholarship as a note.
Set the "Hardware included" to true.

# Description of changes
<!-- What does this PR change and why -->
The information about Turing School was updated to reflect the fact that they offer two $4,000 scholarships that veterans are eligible to apply for and use as tuition credit.
The "Hardware included" flag was set to "true" to reflect the fact that Turing School offers classes on hardware.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #157 
