### PR TITLE
Add mentor to discourse

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -45,7 +45,7 @@ module Api
         @sso.username = current_user.email
         @sso.external_id = current_user.id
         @sso.custom_fields['verified'] = current_user.verified
-        @sso.add_groups = "mentors" if current_user.mentor == true
+        @sso.add_groups = "mentors" if current_user.mentor
         @sso.sso_secret = Discourse::SingleSignOn::SECRET
 
         @redirect_path = @sso.to_url('https://community.operationcode.org/session/sso_login')

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -45,6 +45,7 @@ module Api
         @sso.username = current_user.email
         @sso.external_id = current_user.id
         @sso.custom_fields['verified'] = current_user.verified
+        @sso.add_groups = "mentors" if current_user.mentor == true
         @sso.sso_secret = Discourse::SingleSignOn::SECRET
 
         @redirect_path = @sso.to_url('https://community.operationcode.org/session/sso_login')


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
If a user signs up as a mentor, they are added to the mentors list in Discourse automatically. I wasn't able to figure out how to test the payload (tried signing up a new user and viewing the console, but didn't see anything related to SSO), so I hope this works!

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #117 
