### PR TITLE
Bug/code school validations

### DIFF
--- a/app/models/code_school.rb
+++ b/app/models/code_school.rb
@@ -1,5 +1,5 @@
 class CodeSchool < ApplicationRecord
   validates :name, :url, :logo, presence: true
-  validates_inclusion_of :full_time, :hardware_included, :has_online, :in => [true, false]
+  validates_inclusion_of :full_time, :hardware_included, :has_online, :online_only, :in => [true, false]
   has_many :locations, dependent: :destroy
 end

--- a/app/models/code_school.rb
+++ b/app/models/code_school.rb
@@ -1,5 +1,5 @@
 class CodeSchool < ApplicationRecord
   validates :name, :url, :logo, presence: true
-  validates_inclusion_of :full_time, :hardware_included, :has_online, :online_only, :in => [true, false]
+  validates_inclusion_of :full_time, :hardware_included, :has_online, :in => [true, false]
   has_many :locations, dependent: :destroy
 end

--- a/lib/tasks/schools_from_yml.rake
+++ b/lib/tasks/schools_from_yml.rake
@@ -1,13 +1,13 @@
 namespace :schools do
   desc "Reads from the ./config/code_schools.yml and creates records in the database."
-  task populate: :environment do 
-    schools =  YAML::load_file(File.join("./config", "code_schools.yml"), "r")    
+  task populate: :environment do
+    schools =  YAML::load_file(File.join("./config", "code_schools.yml"), "r")
     schools.each do |school|
       begin
         object = CodeSchool.create!(
-          name: school["name"], 
-          url: school["url"], 
-          logo: school["logo"], 
+          name: school["name"],
+          url: school["url"],
+          logo: school["logo"],
           full_time: school["full_time"],
           hardware_included: school["hardware_included"],
           has_online: school["has_online"],
@@ -24,10 +24,15 @@ namespace :schools do
             zip: location["zip"]
           )
         end
-      rescue ActiveRecord::RecordInvalid => e
-        puts "Failed to create CodeSchool: #{e}"
-        Rails.logger.error e 
+      rescue StandardError => e
+        message = "Failed to create CodeSchool: #{e}"
+
+        puts message
+        Rails.logger.error message
       end
+
+      p "Created #{CodeSchool.count} code schools"
+      p "Created #{Location.count} locations"
     end
   end
 end

--- a/lib/tasks/schools_from_yml.rake
+++ b/lib/tasks/schools_from_yml.rake
@@ -11,7 +11,7 @@ namespace :schools do
           full_time: school["full_time"],
           hardware_included: school["hardware_included"],
           has_online: school["has_online"],
-          # online_only: school["online_only"],
+          online_only: school["online_only"],
           notes: school["notes"]
           )
         school["locations"].each do |location|

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -1,56 +1,55 @@
 require 'test_helper'
 
 class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
-  setup do 
+  setup do
     @school = create(:code_school)
     @school.name = "CoderSchool"
     @school.save
   end
-  
-  test ":validates CodeSchool's required fields" do 
+
+  test ":validates CodeSchool's required fields" do
     params = {
       code_school: {
         name: "CoderSchool"
       }
-    }    
+    }
     post api_v1_code_schools_url, params: params, as: :json
-    
+
     assert JSON.parse(response.body)["errors"].include? "Url can't be blank"
   end
-  
-  test ":index endpoint returns a JSON list of all CodeSchools" do 
-    get api_v1_code_schools_path, as: :json    
+
+  test ":index endpoint returns a JSON list of all CodeSchools" do
+    get api_v1_code_schools_path, as: :json
     assert_equal JSON.parse(response.body)[0]["name"], "CoderSchool"
   end
-  
-  test ":create endpoint creates a CodeSchool successfully" do    
+
+  test ":create endpoint creates a CodeSchool successfully" do
     post api_v1_code_schools_path(@school), params: {code_school: @school}, as: :json
     assert_response :ok
   end
-  
+
   test ":show will not work for a invalid record" do
-    school_count = CodeSchool.count + 1
-    get api_v1_code_school_path(school_count), as: :json
+    get api_v1_code_school_path(99999999), as: :json
     assert_response :missing
   end
-  
+
   test ":show works for a valid record"do
     get api_v1_code_school_path(@school), as: :json
     assert_response :ok
   end
-  
+
   test ":update endpoint updates an existing CodeSchool" do
     put api_v1_code_school_path(@school), params: {name: "CoddderrrrSchool"}, as: :json
     assert_equal response.status, 200
     assert_equal JSON.parse(response.body)["name"], "CoddderrrrSchool"
   end
-  
+
   test ":destroy endpoint destroys an existing CodeSchool" do
     id = @school.id
-    
-    delete api_v1_code_school_path(@school)    
+
+    delete api_v1_code_school_path(@school)
     assert_equal response.status, 200
-    
+
     get api_v1_code_school_path(id), as: :json
     assert_response :missing
   end


### PR DESCRIPTION
# Description of changes
When running the new [rake schools:populate](https://github.com/OperationCode/operationcode_backend/blob/master/lib/tasks/schools_from_yml.rake) task, experienced this error in prod:

```
Failed to create CodeSchool: Validation failed: Online only is not included in the list                                                                                 
E, [2017-10-05T16:22:04.605895 #398] ERROR -- : Validation failed: Online only is not included in the list (ActiveRecord::RecordInvalid)
```

The issue was that the line in the `rake` task that populated the validated field, was commented out.

This PR: 
- uncomments the line
- adds additional logging to the `rake` task's output
- fixes associated tests

