### PR TITLE
Bug/revert code schools index endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -13,41 +13,39 @@ API endpoints that Operation Code's Rails backend makes available to its React f
 
         [
             {
-                "id": 112,
-                "name": "Wyncode Academy",
-                "url": "http://wyncode.co",
-                "logo": "https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/wyncode.jpg",
-                "full_time": true,
-                "hardware_included": false,
-                "has_online": false,
-                "online_only": false,
-                "created_at": "2017-09-21T05:48:50.056Z",
-                "updated_at": "2017-09-21T05:48:50.056Z",
-                "notes": null
+                "name"=>"Galvanize",
+                "url"=>"https://new.galvanize.com", "logo"=>"https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/galvanize.jpg",
+                "full_time"=>true,
+                "hardware_included"=>false,
+                "has_online"=>false,
+                "online_only"=>false,
+                "locations"=> [
+                      {
+                          "va_accepted"=>false,
+                          "address1"=>"44 Tehama Street",
+                          "city"=>"San Francisco",
+                          "state"=>"CA",
+                          "zip"=>94015
+                      },
+                      {
+                          "va_accepted"=>true,
+                          "address1"=>"1062 Delaware Street",
+                          "city"=>"Denver",
+                          "state"=>"CO",
+                          "zip"=>80204
+                      },
+                  ]
             },
-            {
-                "id": 113,
-                "name": "Nashville Software School",
-                "url": "http://nashvillesoftwareschool.com/",
-                "logo": "https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/nss.jpg",
-                "full_time": true,
-                "hardware_included": false,
-                "has_online": false,
-                "online_only": false,
-                "created_at": "2017-09-21T05:48:50.108Z",
-                "updated_at": "2017-09-21T05:48:50.108Z",
-                "notes": null
-            }
         ]
-        
-        
+
+
 ## CodeSchool | Create [/api/v1/code_schools{?name,url,logo,full_time,hardware_included,has_online,online_only,notes}]
-+ Parameters 
-  
++ Parameters
+
   + name (string, required) - The CodeSchool's name
   + url (string, required) - The CodeSchool's url for homepage
   + logo (string, required) - The CodeSchool's logo url
-  + full_time (boolean, required) - Are the CodeSchool's courses full time 
+  + full_time (boolean, required) - Are the CodeSchool's courses full time
   + hardware_included (boolean, required) - Is Hardware included with the CodeSchool
   + has_online (boolean, required) - Does the CodeSchool have an online component
   + online_only (boolean, required) - Is the CodeSchool online only?
@@ -62,7 +60,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
               Authorization: Bearer Access-Token
 
       + Body
-      
+
                   {
                       "code_school": {
                       "name": "CoderSchool",
@@ -73,7 +71,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                       "has_online": "true",
                       "online_only": "false"
                       }
-                  } 
+                  }
 
   + Response 201 (application/json)
 
@@ -88,12 +86,12 @@ API endpoints that Operation Code's Rails backend makes available to its React f
           {
               errors: "Some error message"
           }
-          
+
 ## CodeSchool | Show or Delete [/api/v1/code_schools/{code_school_id}]
 + Parameters
 
     + code_school_id (number) - ID of the CodeSchool in the form of an integer
-  
+
 ### Get an Existing CodeSchool [GET]
 
 + Response 200 (application/json)
@@ -117,7 +115,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
         {
             error: 'No such record'
         }
-              
+
 ### Delete an Existing CodeSchool [DELETE]
 
   + Request (application/json)
@@ -150,12 +148,12 @@ API endpoints that Operation Code's Rails backend makes available to its React f
 
 ## CodeSchool | Update [/api/v1/code_schools/{code_school_id}{?name,url,logo,full_time,hardware_included,has_online,online_only,notes}]
 
-+ Parameters 
-    
++ Parameters
+
     + name (string, required) - The CodeSchool's name
     + url (string, required) - The CodeSchool's url for homepage
     + logo (string, required) - The CodeSchool's logo url
-    + full_time (boolean, required) - Are the CodeSchool's courses full time 
+    + full_time (boolean, required) - Are the CodeSchool's courses full time
     + hardware_included (boolean, required) - Is Hardware included with the CodeSchool
     + has_online (boolean, required) - Does the CodeSchool have an online component
     + online_only (boolean, required) - Is the CodeSchool online only?
@@ -255,7 +253,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
     + tags (string, optional) - Comma-separated list of tags to filter the search results on (i.e. "books, videos")
 
 + Response 200 (application/json)
-            
+
         [
             {
                 "id": 1,

--- a/app/controllers/api/v1/code_schools_controller.rb
+++ b/app/controllers/api/v1/code_schools_controller.rb
@@ -2,20 +2,20 @@ module Api
   module V1
     class CodeSchoolsController < ApplicationController
       def index
-        render json: CodeSchool.all
+        render json: CodeSchools.all
       end
-      
-      def create 
+
+      def create
         school = CodeSchool.new(code_school_params)
-        
-        if school.save 
+
+        if school.save
           render json: school
-        else 
+        else
           render json: { errors: school.errors.full_messages }
         end
       end
-      
-      def show 
+
+      def show
         school = CodeSchool.find_by(id: params[:id])
         if school
           render json: school
@@ -23,27 +23,27 @@ module Api
           render json: { error: 'No such record' }, status: :not_found
         end
       end
-      
-      def update 
-        school = CodeSchool.find(params[:id])        
+
+      def update
+        school = CodeSchool.find(params[:id])
         if school.update(code_school_params)
           render json: school
-        else 
+        else
           render json: { errors: school.errors.full_messages }
         end
       end
-      
+
       def destroy
         school = CodeSchool.find(params[:id])
         if school.destroy
           render json: { status: :ok }
-        else 
+        else
           render json: { errors: school.errors.full_messages }
-        end        
+        end
       end
-      
+
       private
-      
+
       def code_school_params
         params.require(:code_school).permit(:name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only)
       end

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -20,7 +20,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
 
   test ":index endpoint returns a JSON list of all CodeSchools" do
     get api_v1_code_schools_path, as: :json
-    assert_equal JSON.parse(response.body)[0]["name"], "CoderSchool"
+    assert_equal JSON.parse(response.body)[0]["name"], "Wyncode Academy"
   end
 
   test ":create endpoint creates a CodeSchool successfully" do


### PR DESCRIPTION
# Description of changes
The API contract between the front and backend was broken [here](https://github.com/OperationCode/operationcode_backend/pull/164/files#diff-ee716d1d5cd16e06e10da69fe6e514ecL5).  The backend changed the expected JSON structure.

This PR:
- Reverts the `index` action to yield the `code_schools.yml` file
- updates the tests accordingly
- updates the apiary documentation with the former JSON shape  



