### PR TITLE
Updated Sabio logo url in code_schools.yaml to use png

### DIFF
--- a/config/code_schools.yml
+++ b/config/code_schools.yml
@@ -136,7 +136,7 @@
 
 - name: Sabio
   url: http://sabio.la/veterans
-  logo: https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/sabio.jpg
+  logo: https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/sabio.png
   full_time: true
   hardware_included: false
   has_online: true


### PR DESCRIPTION
# Description of changes
- Updated Sabio logo url in code_schools.yaml to use `sabio.png`

# Issue Resolved
Fixes #178

# Reminder: 
There needs to be coordinated deployment between the front and backends.
