### PR TITLE
Feature/175 admin dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'activeadmin', '~> 1.1'
 gem 'active_model_serializers'
 gem 'acts-as-taggable-on', '~> 5.0'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,18 @@ GEM
       activemodel (>= 4.1, < 6)
       case_transform (>= 0.2)
       jsonapi-renderer (>= 0.1.1.beta1, < 0.2)
+    activeadmin (1.1.0)
+      arbre (>= 1.1.1)
+      coffee-rails
+      formtastic (~> 3.1)
+      formtastic_i18n
+      inherited_resources (~> 1.7)
+      jquery-rails
+      kaminari (>= 0.15, < 2.0)
+      railties (>= 4.2, < 5.2)
+      ransack (~> 1.3)
+      sass (~> 3.1)
+      sprockets (< 4.1)
     activejob (5.0.2)
       activesupport (= 5.0.2)
       globalid (>= 0.3.6)
@@ -47,6 +59,8 @@ GEM
       activerecord (>= 4.2.8)
     airtable (0.0.9)
       httparty
+    arbre (1.1.1)
+      activesupport (>= 3.0.0)
     arel (7.1.4)
     awesome_print (1.8.0)
     bcrypt (3.1.11)
@@ -54,6 +68,13 @@ GEM
     byebug (9.0.6)
     case_transform (0.2)
       activesupport
+    coffee-rails (4.2.2)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     devise (4.2.1)
@@ -63,6 +84,7 @@ GEM
       responders
       warden (~> 1.2.3)
     erubis (2.7.0)
+    execjs (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.8.0)
@@ -73,17 +95,44 @@ GEM
     faraday (0.12.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
+    formtastic (3.1.5)
+      actionpack (>= 3.2.13)
+    formtastic_i18n (0.6.0)
     geocoder (1.4.3)
     gibbon (3.0.1)
       faraday (>= 0.9.1)
       multi_json (>= 1.11.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    has_scope (0.7.1)
+      actionpack (>= 4.1, < 5.2)
+      activesupport (>= 4.1, < 5.2)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
     i18n (0.8.1)
+    inherited_resources (1.7.2)
+      actionpack (>= 3.2, < 5.2.x)
+      has_scope (~> 0.6)
+      railties (>= 3.2, < 5.2.x)
+      responders
+    jquery-rails (4.3.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     jsonapi-renderer (0.1.2)
     jwt (1.5.6)
+    kaminari (1.1.0)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.0)
+      kaminari-activerecord (= 1.1.0)
+      kaminari-core (= 1.1.0)
+    kaminari-actionview (1.1.0)
+      actionview
+      kaminari-core (= 1.1.0)
+    kaminari-activerecord (1.1.0)
+      activerecord
+      kaminari-core (= 1.1.0)
+    kaminari-core (1.1.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -119,6 +168,8 @@ GEM
       httparty
     orm_adapter (0.5.0)
     pg (0.20.0)
+    polyamorous (1.3.1)
+      activerecord (>= 3.0)
     puma (3.8.2)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
@@ -152,6 +203,12 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
+    ransack (1.8.4)
+      actionpack (>= 3.0)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
+      i18n
+      polyamorous (~> 1.3)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -159,6 +216,11 @@ GEM
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     ruby_http_client (3.0.2)
+    sass (3.5.2)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sendgrid-ruby (4.0.8)
       ruby_http_client (~> 3.0.1)
     sentry-raven (2.5.3)
@@ -195,6 +257,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  activeadmin (~> 1.1)
   acts-as-taggable-on (~> 5.0)
   awesome_print (~> 1.8)
   byebug
@@ -224,4 +287,4 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -1,0 +1,28 @@
+ActiveAdmin.register AdminUser do
+  permit_params :email, :password, :password_confirmation
+
+  index do
+    selectable_column
+    id_column
+    column :email
+    column :current_sign_in_at
+    column :sign_in_count
+    column :created_at
+    actions
+  end
+
+  filter :email
+  filter :current_sign_in_at
+  filter :sign_in_count
+  filter :created_at
+
+  form do |f|
+    f.inputs do
+      f.input :email
+      f.input :password
+      f.input :password_confirmation
+    end
+    f.actions
+  end
+
+end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,0 +1,22 @@
+ActiveAdmin.register_page "Dashboard" do
+  menu priority: 1, label: proc{ I18n.t("active_admin.dashboard") }
+
+  content title: proc{ I18n.t("active_admin.dashboard") } do
+    columns do
+      column do
+        panel "New User Counts" do
+          para "Today: #{User.count_created_since(Date.today)}"
+          para "In the last week: #{User.count_created_since(1.week.ago)}"
+          para "In the last month: #{User.count_created_since(1.month.ago)}"
+          para "In the last year: #{User.count_created_since(1.year.ago)}"
+        end
+      end
+
+      column do
+        panel "Verified Users" do
+          para User.verified.count
+        end
+      end
+    end
+  end
+end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,0 +1,52 @@
+ActiveAdmin.register User do
+  permit_params :id, :email, :zip, :latitude, :longitude, :created_at, :updated_at,
+    :encrypted_password, :reset_password_token, :reset_password_sent_at,
+    :remember_created_at, :sign_in_count, :current_sign_in_at, :last_sign_in_at,
+    :current_sign_in_ip, :last_sign_in_ip, :mentor, :slack_name, :first_name,
+    :last_name, :timezone, :bio, :verified, :state, :address_1, :address_2, :city,
+    :username, :volunteer, :branch_of_service, :years_of_service, :pay_grade,
+    :military_occupational_specialty, :github, :twitter, :linkedin, :employment_status,
+    :education, :company_role, :company_name, :education_level, :interests
+
+  scope :all
+  scope :mentors
+  scope :verified
+
+  index do
+    selectable_column
+    column :id
+    column :email
+    column :zip
+    column :created_at
+    column :sign_in_count
+    column :last_sign_in_at
+    column :mentor
+    column :slack_name
+    column :first_name
+    column :last_name
+    column :timezone
+    column :bio
+    column :verified
+    column :state
+    column :city
+    column :username
+    column :volunteer
+    column :branch_of_service
+    column :years_of_service
+    column :pay_grade
+    column :military_occupational_specialty
+    column :github
+    column :twitter
+    column :linkedin
+    column :employment_status
+    column :education
+    column :company_role
+    column :company_name
+    column :education_level
+    column :interests
+    actions
+  end
+
+  preserve_default_filters!
+  filter :state, as: :select, collection: ->{ User.uniq_states }
+end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -88,5 +88,5 @@ ActiveAdmin.register User do
   remove_filter :base_tags
   remove_filter :taggings
   remove_filter :tag_taggings
-  filter :with_tags, label: 'Tagged With', as: :select, collection: ->{ User.all_tags }
+  filter :with_tags, label: 'Tagged With', as: :select, collection: ->{ User.all_tag_names }
 end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -84,4 +84,5 @@ ActiveAdmin.register User do
 
   preserve_default_filters!
   filter :state, as: :select, collection: ->{ User.uniq_states }
+  filter :with_tags, label: 'Tagged With', as: :select, collection: ->{ User.all_tags }
 end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -12,6 +12,41 @@ ActiveAdmin.register User do
   scope :mentors
   scope :verified
 
+  ## Action Items
+  ## https://activeadmin.info/8-custom-actions.html#action-items
+
+  action_item :community_leader, only: :show do
+    link_to 'Community Leader', community_leader_admin_user_path(user), method: :put if !user.has_tag?(User::LEADER)
+  end
+
+  action_item :non_community_leader, only: :show do
+    link_to 'Remove Community Leader', non_community_leader_admin_user_path(user), method: :put if user.has_tag?(User::LEADER)
+  end
+
+  ## Member Actions
+  ## https://activeadmin.info/8-custom-actions.html#member-actions
+
+  member_action :community_leader, method: :put do
+    user = User.find(params[:id])
+
+    user.tag_list.add User::LEADER
+    user.save!
+
+    redirect_to admin_user_path(user), notice: "#{user.first_name} is now a #{User::LEADER}!"
+  end
+
+  member_action :non_community_leader, method: :put do
+    user = User.find(params[:id])
+
+    user.tag_list.remove User::LEADER
+    user.save!
+
+    redirect_to admin_user_path(user), notice: "#{user.first_name} is no longer a #{User::LEADER}"
+  end
+
+  ## Index as a Table
+  ## https://activeadmin.info/3-index-pages/index-as-table.html
+
   index do
     selectable_column
     column :id

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -84,5 +84,9 @@ ActiveAdmin.register User do
 
   preserve_default_filters!
   filter :state, as: :select, collection: ->{ User.uniq_states }
+  remove_filter :tags
+  remove_filter :base_tags
+  remove_filter :taggings
+  remove_filter :tag_taggings
   filter :with_tags, label: 'Tagged With', as: :select, collection: ->{ User.all_tags }
 end

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,0 +1,1 @@
+#= require active_admin/base

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -1,0 +1,17 @@
+// SASS variable overrides must be declared before loading up Active Admin's styles.
+//
+// To view the variables that Active Admin provides, take a look at
+// `app/assets/stylesheets/active_admin/mixins/_variables.scss` in the
+// Active Admin source.
+//
+// For example, to change the sidebar width:
+// $sidebar-width: 242px;
+
+// Active Admin's got SASS!
+@import "active_admin/mixins";
+@import "active_admin/base";
+
+// Overriding any non-variable SASS must be done after the fact.
+// For example, to change the default status-tag color:
+//
+//   .status_tag { background: #6090DB; }

--- a/app/controllers/api/v1/code_schools_controller.rb
+++ b/app/controllers/api/v1/code_schools_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class CodeSchoolsController < ApplicationController
+    class CodeSchoolsController < ApiController
       def index
         render json: CodeSchools.all
       end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class EventsController < ApplicationController
+    class EventsController < ApiController
       def index
         render json: Event.all
       end

--- a/app/controllers/api/v1/mentors_controller.rb
+++ b/app/controllers/api/v1/mentors_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class MentorsController < ApplicationController
+    class MentorsController < ApiController
       before_action :authenticate_user!
 
       def index

--- a/app/controllers/api/v1/requests_controller.rb
+++ b/app/controllers/api/v1/requests_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class RequestsController < ApplicationController
+    class RequestsController < ApiController
       before_action :authenticate_user!
 
       def index

--- a/app/controllers/api/v1/resources_controller.rb
+++ b/app/controllers/api/v1/resources_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class ResourcesController < ApplicationController
+    class ResourcesController < ApiController
       before_action :authenticate_user!, except: [:index, :show]
       before_filter :set_resource, only: [:show, :update, :destroy]
 

--- a/app/controllers/api/v1/scholarship_applications_controller.rb
+++ b/app/controllers/api/v1/scholarship_applications_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class ScholarshipApplicationsController < ApplicationController
+    class ScholarshipApplicationsController < ApiController
       def create
         current_user.scholarship_applications.create! scholarship_application_params
 

--- a/app/controllers/api/v1/scholarships_controller.rb
+++ b/app/controllers/api/v1/scholarships_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class ScholarshipsController < ApplicationController
+    class ScholarshipsController < ApiController
       def index
         render json: Scholarship.all
       end

--- a/app/controllers/api/v1/services_controller.rb
+++ b/app/controllers/api/v1/services_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class ServicesController < ApplicationController
+    class ServicesController < ApiController
       before_action :authenticate_user!
 
       def index

--- a/app/controllers/api/v1/slack_users_controller.rb
+++ b/app/controllers/api/v1/slack_users_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class SlackUsersController < ApplicationController
+    class SlackUsersController < ApiController
       before_action :authenticate_user!
 
       def create

--- a/app/controllers/api/v1/squads_controller.rb
+++ b/app/controllers/api/v1/squads_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class SquadsController < ApplicationController
+    class SquadsController < ApiController
       before_action :authenticate_user!
 
       def index

--- a/app/controllers/api/v1/status_controller.rb
+++ b/app/controllers/api/v1/status_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class StatusController < ApplicationController
+    class StatusController < ApiController
       before_action :authenticate_user!, only: :protected
 
       def all

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class TagsController < ApplicationController
+    class TagsController < ApiController
       def index
         render json: ActsAsTaggableOn::Tag.all, status: :ok
       rescue StandardError => e

--- a/app/controllers/api/v1/team_members_controller.rb
+++ b/app/controllers/api/v1/team_members_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class TeamMembersController < ApplicationController
+    class TeamMembersController < ApiController
       before_action :authenticate_user!, except: :index
 
       def index

--- a/app/controllers/api/v1/users/passwords_controller.rb
+++ b/app/controllers/api/v1/users/passwords_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     module Users
-      class PasswordsController < ApplicationController
+      class PasswordsController < ApiController
 
         # Resets password token and sends reset password instructions by email.
         #

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class UsersController < ApplicationController
+    class UsersController < ApiController
       before_action :authenticate_user!, only: %i[update]
 
       def index

--- a/app/controllers/api/v1/votes_controller.rb
+++ b/app/controllers/api/v1/votes_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class VotesController < ApplicationController
+    class VotesController < ApiController
       before_action :authenticate_user!
 
       def create

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,2 @@
+class ApiController < ActionController::API
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,2 +1,4 @@
 class ApiController < ActionController::API
+  wrap_parameters format: [:json]
+  include Pundit
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+  # Prevent CSRF attacks by raising an exception.
+  # For APIs, you may want to use :null_session instead.
+  protect_from_forgery with: :exception
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
-class ApplicationController < ActionController::API
+class ApplicationController < ActionController::Base
   wrap_parameters format: [:json]
   include Pundit
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,2 @@
 class ApplicationController < ActionController::Base
-  wrap_parameters format: [:json]
-  include Pundit
 end

--- a/app/inputs/inet_input.rb
+++ b/app/inputs/inet_input.rb
@@ -1,0 +1,2 @@
+class InetInput < Formtastic::Inputs::StringInput
+end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,0 +1,6 @@
+class AdminUser < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, 
+         :recoverable, :rememberable, :trackable, :validatable
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
   scope :mentors, -> { where(mentor: true) }
   scope :by_zip, ->(zip) { where(zip: zip) }
   scope :by_state, ->(state) { where(state: state) }
+  scope :verified, -> { where(verified: true) }
 
   # Returns a count of all users with the passed in zip code(s)
   #
@@ -71,6 +72,26 @@ class User < ApplicationRecord
   #
   def self.count_by_location(location, radius=20)
     near(location, radius.to_i)&.size
+  end
+
+  # Returns a count of users that were created since the passed in date,
+  # up through today.
+  #
+  # @param date [Date] The date the range should begin at (i.e. Date.today, 1.week.ago)
+  # @return [Intenger] A count of users
+  #
+  def self.count_created_since(date)
+    range = date.beginning_of_day..Date.today.end_of_day
+
+    where(created_at: range).count
+  end
+
+  def self.uniq_states
+    self
+      .order(:state)
+      .pluck(:state)
+      .uniq
+      .compact
   end
 
   def name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  LEADER = 'community leader'
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -120,6 +122,10 @@ class User < ApplicationRecord
 
   def token
     JsonWebToken.encode(user_id: self.id, roles: [], email: self.email, verified: verified)
+  end
+
+  def has_tag?(tag)
+    tag_list.include? tag
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  acts_as_taggable
+
   geocoded_by :zip do |user, results|
     geocoded_object = results.first
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,6 +98,34 @@ class User < ApplicationRecord
       .compact
   end
 
+  def self.all_tags
+    tag_counts.order(:name).map(&:name)
+  end
+
+  # The presence of this method is a necessary dependency in order to
+  # add a custom scope in ActiveAdmin, using Ransack
+  #
+  # @see User.with_tags
+  # @see https://github.com/activerecord-hackery/ransack#using-scopesclass-methods
+  #
+  def self.ransackable_scopes(auth_object = nil)
+    [:with_tags]
+  end
+
+  # This calls the ActsAsTaggableOn#tagged_with method with the passed
+  # in tag.
+  #
+  # By setting any: true, it returns results with any of the specified tags.
+  #
+  # @param *args [Array<String>] Array of passed in tag name(s)
+  # @return [User] ActiveRecord collection of User objects
+  # @see User.ransackable_scopes
+  # @see https://github.com/mbleigh/acts-as-taggable-on#finding-tagged-objects
+  #
+  def self.with_tags(*args)
+    tagged_with(args, any: true)
+  end
+
   def name
     "#{first_name} #{last_name}"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,7 +108,7 @@ class User < ApplicationRecord
   # @see User.with_tags
   # @see https://github.com/activerecord-hackery/ransack#using-scopesclass-methods
   #
-  def self.ransackable_scopes(auth_object = nil)
+  def self.ransackable_scopes(_auth_object = nil)
     [:with_tags]
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,7 +98,7 @@ class User < ApplicationRecord
       .compact
   end
 
-  def self.all_tags
+  def self.all_tag_names
     tag_counts.order(:name).map(&:name)
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "action_cable/engine"
-# require "sprockets/railtie"
+require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
@@ -26,12 +26,18 @@ module OperationcodeBackend
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.middleware.use Rack::MethodOverride
+    config.middleware.use ActionDispatch::Flash
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
+
     config.active_job.queue_adapter = :sidekiq
     config.log_level = :debug
 
     config.logger = Logger.new(STDOUT)
     config.lograge.enabled = true
 
-    config.secret_path = Rails.root.join('run/secrets')   
+    config.secret_path = Rails.root.join('run/secrets')
   end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -104,7 +104,7 @@ ActiveAdmin.setup do |config|
   # link. For example :get, :delete, :put, etc..
   #
   # Default:
-  # config.logout_link_method = :get
+  config.logout_link_method = :delete
 
   # == Root
   #

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -1,0 +1,293 @@
+ActiveAdmin.setup do |config|
+  # == Site Title
+  #
+  # Set the title that is displayed on the main layout
+  # for each of the active admin pages.
+  #
+  config.site_title = "Operation Code"
+
+  # Set the link url for the title. For example, to take
+  # users to your main site. Defaults to no link.
+  #
+  # config.site_title_link = "/"
+
+  # Set an optional image to be displayed for the header
+  # instead of a string (overrides :site_title)
+  #
+  # Note: Aim for an image that's 21px high so it fits in the header.
+  #
+  # config.site_title_image = "logo.png"
+
+  # == Default Namespace
+  #
+  # Set the default namespace each administration resource
+  # will be added to.
+  #
+  # eg:
+  #   config.default_namespace = :hello_world
+  #
+  # This will create resources in the HelloWorld module and
+  # will namespace routes to /hello_world/*
+  #
+  # To set no namespace by default, use:
+  #   config.default_namespace = false
+  #
+  # Default:
+  # config.default_namespace = :admin
+  #
+  # You can customize the settings for each namespace by using
+  # a namespace block. For example, to change the site title
+  # within a namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.site_title = "Custom Admin Title"
+  #   end
+  #
+  # This will ONLY change the title for the admin section. Other
+  # namespaces will continue to use the main "site_title" configuration.
+
+  # == User Authentication
+  #
+  # Active Admin will automatically call an authentication
+  # method in a before filter of all controller actions to
+  # ensure that there is a currently logged in admin user.
+  #
+  # This setting changes the method which Active Admin calls
+  # within the application controller.
+  config.authentication_method = :authenticate_admin_user!
+
+  # == User Authorization
+  #
+  # Active Admin will automatically call an authorization
+  # method in a before filter of all controller actions to
+  # ensure that there is a user with proper rights. You can use
+  # CanCanAdapter or make your own. Please refer to documentation.
+  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+
+  # In case you prefer Pundit over other solutions you can here pass
+  # the name of default policy class. This policy will be used in every
+  # case when Pundit is unable to find suitable policy.
+  # config.pundit_default_policy = "MyDefaultPunditPolicy"
+
+  # You can customize your CanCan Ability class name here.
+  # config.cancan_ability_class = "Ability"
+
+  # You can specify a method to be called on unauthorized access.
+  # This is necessary in order to prevent a redirect loop which happens
+  # because, by default, user gets redirected to Dashboard. If user
+  # doesn't have access to Dashboard, he'll end up in a redirect loop.
+  # Method provided here should be defined in application_controller.rb.
+  # config.on_unauthorized_access = :access_denied
+
+  # == Current User
+  #
+  # Active Admin will associate actions with the current
+  # user performing them.
+  #
+  # This setting changes the method which Active Admin calls
+  # (within the application controller) to return the currently logged in user.
+  config.current_user_method = :current_admin_user
+
+  # == Logging Out
+  #
+  # Active Admin displays a logout link on each screen. These
+  # settings configure the location and method used for the link.
+  #
+  # This setting changes the path where the link points to. If it's
+  # a string, the strings is used as the path. If it's a Symbol, we
+  # will call the method to return the path.
+  #
+  # Default:
+  config.logout_link_path = :destroy_admin_user_session_path
+
+  # This setting changes the http method used when rendering the
+  # link. For example :get, :delete, :put, etc..
+  #
+  # Default:
+  # config.logout_link_method = :get
+
+  # == Root
+  #
+  # Set the action to call for the root path. You can set different
+  # roots for each namespace.
+  #
+  # Default:
+  # config.root_to = 'dashboard#index'
+
+  # == Admin Comments
+  #
+  # This allows your users to comment on any resource registered with Active Admin.
+  #
+  # You can completely disable comments:
+  # config.comments = false
+  #
+  # You can change the name under which comments are registered:
+  # config.comments_registration_name = 'AdminComment'
+  #
+  # You can change the order for the comments and you can change the column
+  # to be used for ordering:
+  # config.comments_order = 'created_at ASC'
+  #
+  # You can disable the menu item for the comments index page:
+  # config.comments_menu = false
+  #
+  # You can customize the comment menu:
+  # config.comments_menu = { parent: 'Admin', priority: 1 }
+
+  # == Batch Actions
+  #
+  # Enable and disable Batch Actions
+  #
+  config.batch_actions = true
+
+  # == Controller Filters
+  #
+  # You can add before, after and around filters to all of your
+  # Active Admin resources and pages from here.
+  #
+  # config.before_action :do_something_awesome
+
+  # == Localize Date/Time Format
+  #
+  # Set the localize format to display dates and times.
+  # To understand how to localize your app with I18n, read more at
+  # https://github.com/svenfuchs/i18n/blob/master/lib%2Fi18n%2Fbackend%2Fbase.rb#L52
+  #
+  config.localize_format = :long
+
+  # == Setting a Favicon
+  #
+  # config.favicon = 'favicon.ico'
+
+  # == Meta Tags
+  #
+  # Add additional meta tags to the head element of active admin pages.
+  #
+  # Add tags to all pages logged in users see:
+  #   config.meta_tags = { author: 'My Company' }
+
+  # By default, sign up/sign in/recover password pages are excluded
+  # from showing up in search engine results by adding a robots meta
+  # tag. You can reset the hash of meta tags included in logged out
+  # pages:
+  #   config.meta_tags_for_logged_out_pages = {}
+
+  # == Removing Breadcrumbs
+  #
+  # Breadcrumbs are enabled by default. You can customize them for individual
+  # resources or you can disable them globally from here.
+  #
+  # config.breadcrumb = false
+
+  # == Create Another Checkbox
+  #
+  # Create another checkbox is disabled by default. You can customize it for individual
+  # resources or you can enable them globally from here.
+  #
+  # config.create_another = true
+
+  # == Register Stylesheets & Javascripts
+  #
+  # We recommend using the built in Active Admin layout and loading
+  # up your own stylesheets / javascripts to customize the look
+  # and feel.
+  #
+  # To load a stylesheet:
+  #   config.register_stylesheet 'my_stylesheet.css'
+  #
+  # You can provide an options hash for more control, which is passed along to stylesheet_link_tag():
+  #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
+  #
+  # To load a javascript file:
+  #   config.register_javascript 'my_javascript.js'
+
+  # == CSV options
+  #
+  # Set the CSV builder separator
+  # config.csv_options = { col_sep: ';' }
+  #
+  # Force the use of quotes
+  # config.csv_options = { force_quotes: true }
+
+  # == Menu System
+  #
+  # You can add a navigation menu to be used in your application, or configure a provided menu
+  #
+  # To change the default utility navigation to show a link to your website & a logout btn
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :utility_navigation do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #       admin.add_logout_button_to_menu menu
+  #     end
+  #   end
+  #
+  # If you wanted to add a static menu item to the default menu provided:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :default do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #     end
+  #   end
+
+  # == Download Links
+  #
+  # You can disable download links on resource listing pages,
+  # or customize the formats shown per namespace/globally
+  #
+  # To disable/customize for the :admin namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #
+  #     # Disable the links entirely
+  #     admin.download_links = false
+  #
+  #     # Only show XML & PDF options
+  #     admin.download_links = [:xml, :pdf]
+  #
+  #     # Enable/disable the links based on block
+  #     #   (for example, with cancan)
+  #     admin.download_links = proc { can?(:view_download_links) }
+  #
+  #   end
+
+  # == Pagination
+  #
+  # Pagination is enabled by default for all resources.
+  # You can control the default per page count for all resources here.
+  #
+  # config.default_per_page = 30
+  #
+  # You can control the max per page count too.
+  #
+  # config.max_per_page = 10_000
+
+  # == Filters
+  #
+  # By default the index screen includes a "Filters" sidebar on the right
+  # hand side with a filter for each attribute of the registered model.
+  # You can enable or disable them for all resources here.
+  #
+  # config.filters = true
+  #
+  # By default the filters include associations in a select, which means
+  # that every record will be loaded for each association.
+  # You can enabled or disable the inclusion
+  # of those filters by default here.
+  #
+  # config.include_default_association_filters = true
+
+  # == Footer
+  #
+  # By default, the footer shows the current Active Admin version. You can
+  # override the content of the footer here.
+  #
+  # config.footer = 'my custom footer text'
+
+  # == Sorting
+  #
+  # By default ActiveAdmin::OrderClause is used for sorting logic
+  # You can inherit it with own class and inject it for all resources
+  #
+  # config.order_clause = MyOrderClause
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  devise_for :admin_users, ActiveAdmin::Devise.config
+  ActiveAdmin.routes(self)
   devise_for :users
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/migrate/20171013230050_devise_create_admin_users.rb
+++ b/db/migrate/20171013230050_devise_create_admin_users.rb
@@ -1,0 +1,42 @@
+class DeviseCreateAdminUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :admin_users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet     :current_sign_in_ip
+      t.inet     :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :admin_users, :email,                unique: true
+    add_index :admin_users, :reset_password_token, unique: true
+    # add_index :admin_users, :confirmation_token,   unique: true
+    # add_index :admin_users, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20171013230053_create_active_admin_comments.rb
+++ b/db/migrate/20171013230053_create_active_admin_comments.rb
@@ -1,0 +1,17 @@
+class CreateActiveAdminComments < ActiveRecord::Migration::Current
+  def self.up
+    create_table :active_admin_comments do |t|
+      t.string :namespace
+      t.text   :body
+      t.references :resource, polymorphic: true
+      t.references :author, polymorphic: true
+      t.timestamps
+    end
+    add_index :active_admin_comments, [:namespace]
+
+  end
+
+  def self.down
+    drop_table :active_admin_comments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170921055331) do
+ActiveRecord::Schema.define(version: 20171013230053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_admin_comments", force: :cascade do |t|
+    t.string   "namespace"
+    t.text     "body"
+    t.string   "resource_type"
+    t.integer  "resource_id"
+    t.string   "author_type"
+    t.integer  "author_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
+    t.index ["namespace"], name: "index_active_admin_comments_on_namespace", using: :btree
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
+  end
+
+  create_table "admin_users", force: :cascade do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet     "current_sign_in_ip"
+    t.inet     "last_sign_in_ip"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.index ["email"], name: "index_admin_users_on_email", unique: true, using: :btree
+    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true, using: :btree
+  end
 
   create_table "code_schools", force: :cascade do |t|
     t.string   "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,3 +37,6 @@ end
 team_members_seed_file = Rails.root.join('config', 'team_members.yml')
 config = YAML::load_file(team_members_seed_file)
 TeamMember.create!(config)
+
+# Create Admin (development only)
+AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password') if Rails.env.development?


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Creates an admin dashboard using [ActiveAdmin](https://activeadmin.info/index.html).

- [x] On the `User` page, it should provide a broad filtering mechanism to query for any number of one-off criteria, based on the `User` tables attributes
- [x] Can create, edit, view and/or delete `User`s
- [x] Can create, edit, view and/or delete `AdminUser`s

On the `User` page, it should be able to filter users by:
- [x] mentor
- [x] state
- [x] verified status
- [x] tag name

On the main dashboard, it should display
- [x] How many users today
- [x] How many users over last week
- [x] How many users over last month
- [x] How many users over last year
- [x] Number of verified users

On a `User`'s show page:
- [x] A button that tags/un-tags the user with "community leader"

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #175 
