### PR TITLE
Add cincy code it bootcamps object

### DIFF
--- a/config/code_schools.yml
+++ b/config/code_schools.yml
@@ -787,3 +787,18 @@
       city: San Francisco
       state: CA
       zip: 94110
+
+- name: Cincy Code IT Bootcamps
+  url: https://maxtrain.com/career/
+  logo: https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/cincy_code_it_bootcamps.jpg
+  full_time: true
+  hardware_included: true
+  has_online: false
+  online_only: false
+  locations:
+    - va_accepted: true
+      address1: 4900 Parkway Dr
+      address2: Suite 160
+      city: Cincinnati
+      state: OH
+      zip: 45040


### PR DESCRIPTION
# Description of changes
This PR adds an `cincy code it bootcamp` entry in our /code_schools api response and adds it to our /code_schools page. This PR is dependent on https://github.com/OperationCode/operationcode_frontend/pull/727

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #190 
