### PR TITLE
feature/191-database-env-variable

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -21,7 +21,7 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   user: postgres
-  host: operationcode-psql
+  host: <%= ENV['POSTGRES_HOST'].present? ? ENV['POSTGRES_HOST'] : 'operationcode-psql' %>
   password: <%= OperationCode.fetch_secret_with name: :postgres_password %>
 
 development:
@@ -34,5 +34,5 @@ test:
 
 production:
   <<: *default
-  host: operationcode-psql-postgresql
+  host: <%= ENV['POSTGRES_HOST'].present? ? ENV['POSTGRES_HOST'] : 'operationcode-psql-postgresql' %>
   database: operationcode_production


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Favors database host to be configurable at runtime via an environment variable.  If one is not present, defaults to the named hosts.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #191 
