### PR TITLE
Update airtable code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ end
 
 gem 'active_model_serializers'
 gem 'acts-as-taggable-on', '~> 5.0'
+gem 'airrecord' # Gem for interfacing with AirTable
 gem 'devise'
 gem 'geocoder'
 gem 'gibbon'
@@ -17,7 +18,6 @@ gem 'httparty'
 gem 'jwt'
 gem 'lograge'
 gem 'logstash-event'
-gem 'operationcode-airtable'
 gem 'operationcode-slack'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,9 @@ GEM
       activerecord (>= 4.2.8)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    airtable (0.0.9)
-      httparty
+    airrecord (0.2.3)
+      faraday (~> 0.10)
+      net-http-persistent (~> 2.9)
     arel (7.1.4)
     awesome_print (1.8.0)
     bcrypt (3.1.11)
@@ -114,12 +115,10 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    net-http-persistent (2.9.4)
     nio4r (2.0.0)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
-    operationcode-airtable (0.3.0)
-      activesupport
-      airtable
     operationcode-slack (0.6.0)
       activesupport
       httparty
@@ -214,6 +213,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   acts-as-taggable-on (~> 5.0)
+  airrecord
   awesome_print (~> 1.8)
   byebug
   devise
@@ -227,7 +227,6 @@ DEPENDENCIES
   lograge
   logstash-event
   mocha
-  operationcode-airtable
   operationcode-slack
   pg (~> 0.18)
   pry-rails

--- a/app/jobs/update_user_in_airtables_job.rb
+++ b/app/jobs/update_user_in_airtables_job.rb
@@ -1,0 +1,26 @@
+class UpdateUserInAirtablesJob < ActiveJob::Base
+  queue_as :default
+
+  Airrecord.api_key = OperationCode.fetch_secret_with(name: :airtable_api_key)
+
+  def perform(user)
+    @user = user
+
+    member_array = AirTableMember.all(filter: "ID = #{user.id}")
+
+    if member_array.empty?
+      AddUserToAirtablesJob.perform_later(user)
+    else
+      member = member_array.first
+      member[:first_name] = user.first_name
+      member[:last_name] = user.last_name
+      member[:slack_name] = user.slack_name
+      member[:education] = user.education
+      member[:employment_status] = user.employment_status
+      member[:zip] = user.zip
+
+      member.save
+    end
+  end
+
+end

--- a/app/lib/airtables_bulk_import.rb
+++ b/app/lib/airtables_bulk_import.rb
@@ -1,0 +1,7 @@
+class AirtablesBulkImport
+  def self.execute
+    User.all.each do |user|
+      AddUserToAirtablesJob.perform_later(user)
+    end
+  end
+end

--- a/app/models/air_table_member.rb
+++ b/app/models/air_table_member.rb
@@ -1,0 +1,7 @@
+# For use to insert user information into Airtable
+# Using the airrecord gem
+
+class AirTableMember <  Airrecord::Table
+  self.base_key = OperationCode.fetch_secret_with(name: :airtable_add_user_base_id)
+  self.table_name = OperationCode.fetch_secret_with(name: :airtable_add_user_table_name)
+end

--- a/test/jobs/update_user_in_airtables_job_test.rb
+++ b/test/jobs/update_user_in_airtables_job_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class UpdateUserInAirtablesJobTest < ActiveJob::TestCase
+  test 'it finds the user in airtables' do
+    user = create(:user)
+    member = mock_air_table_member_for(user)
+
+    AirTableMember.expects(:all).returns([member])
+    AirTableMember.any_instance.stubs(:save).returns(true)
+
+    UpdateUserInAirtablesJob.perform_now(user)
+  end
+
+  test 'it updates the user in airtables' do
+    user = create(:user)
+    member = mock_air_table_member_for(user)
+
+    AirTableMember.stubs(:all).returns([member])
+
+    AirTableMember.any_instance.expects(:save).once
+
+    UpdateUserInAirtablesJob.perform_now(user)
+  end
+
+  test 'it creates the user if the user does not exist' do
+    user = create(:user)
+    member = mock_air_table_member_for(user)
+
+    AirTableMember.stubs(:all).returns([])
+
+    AddUserToAirtablesJob.expects(:perform_later).with(user)
+
+    UpdateUserInAirtablesJob.perform_now(user)
+  end
+
+  private
+
+  def mock_air_table_member_for(user)
+    member = AirTableMember.new(
+      id: user.id,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      slack_name: user.slack_name,
+      education: user.education,
+      employment_status: user.employment_status,
+      email: user.email,
+      zip: user.zip,
+    )
+  end
+end

--- a/test/lib/airtables_bulk_import_test.rb
+++ b/test/lib/airtables_bulk_import_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class AirtablesBulkImportTest < ActiveSupport::TestCase
+  test 'finds all users' do
+    User.expects(:all).returns([])
+    AirtablesBulkImport.execute
+  end
+
+  test 'queues a job for a user' do
+    tom = create :user
+
+    AddUserToAirtablesJob.expects(:perform_later).with(tom)
+    AirtablesBulkImport.execute
+  end
+
+  test 'queues jobs for all users' do
+    tom = create :user
+    sam = create :user
+ 
+    AddUserToAirtablesJob.expects(:perform_later).twice
+    AirtablesBulkImport.execute
+  end
+
+end


### PR DESCRIPTION
# Description of changes

Our Airtable integration appears to have been broken for some time.  It looks like the secrets related to the Airtable API did not make it into Kubernetes.  I also discovered that we created our own Airtables API related gem, but it has not been updated in a year and appears to be no longer working.  Rather than keep maintaining a gem of our own, I looked for one which is currently maintained and settled on [Airrecord](https://github.com/sirupsen/airrecord).  This PR refactors the Airtable code to use this gem.

A few notes: 

I have unfortunately not been able to test the code as a whole locally (though I have tested all the pieces).  When User.create is run in the development environment, I get this error, which may be an issue with the dev environment itself:

```bash
sidekiq_1             | 2017-12-13T04:31:27.813Z 1 TID-v44w4 AddUserToAirtablesJob JID-9a086e29d47881a57ba7af7b INFO: start
operationcode-psql_1  | 2017-12-13 04:31:27.818 UTC [207] FATAL:  database "operationcode-psql" does not exist
sidekiq_1             | 2017-12-13T04:31:27.819Z 1 TID-v44w4 AddUserToAirtablesJob JID-9a086e29d47881a57ba7af7b INFO: fail: 0.006 sec
sidekiq_1             | 2017-12-13T04:31:27.821Z 1 TID-v44w4 WARN: {"context":"Job raised exception","job":{"class":"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapp
er","wrapped":"AddUserToAirtablesJob","queue":"default","args":[{"job_class":"AddUserToAirtablesJob","job_id":"60259575-6921-4c5b-bffb-9de0fadb855a","queue_name":"defa
ult","priority":null,"arguments":[{"_aj_globalid":"gid://operationcode-backend/User/2"}],"locale":"en"}],"retry":true,"jid":"9a086e29d47881a57ba7af7b","created_at":151
3136550.021082,"enqueued_at":1513139487.810564,"error_message":"Error while trying to deserialize arguments: FATAL:  database \"operationcode-psql\" does not exist\n",
"error_class":"ActiveJob::DeserializationError","failed_at":1513136550.037713,"retry_count":7,"retried_at":1513139487.8197815},"jobstr":"{\"class\":\"ActiveJob::QueueA
dapters::SidekiqAdapter::JobWrapper\",\"wrapped\":\"AddUserToAirtablesJob\",\"queue\":\"default\",\"args\":[{\"job_class\":\"AddUserToAirtablesJob\",\"job_id\":\"60259
575-6921-4c5b-bffb-9de0fadb855a\",\"queue_name\":\"default\",\"priority\":null,\"arguments\":[{\"_aj_globalid\":\"gid://operationcode-backend/User/2\"}],\"locale\":\"e
n\"}],\"retry\":true,\"jid\":\"9a086e29d47881a57ba7af7b\",\"created_at\":1513136550.021082,\"enqueued_at\":1513139487.810564,\"error_message\":\"Error while trying to
deserialize arguments: FATAL:  database \\\"operationcode-psql\\\" does not exist\\n\",\"error_class\":\"ActiveJob::DeserializationError\",\"failed_at\":1513136550.037
713,\"retry_count\":6,\"retried_at\":1513138052.4277194}"}
sidekiq_1             | 2017-12-13T04:31:27.821Z 1 TID-v44w4 WARN: ActiveJob::DeserializationError: Error while trying to deserialize arguments: FATAL:  database "oper
ationcode-psql" does not exist
```

Also - in order for this code to work, we will need to add in these secrets (I can provide the values)

airtable_api_key
airtable_add_user_base_id
airtable_add_user_table_name

# Issue Resolved
This is a partial fix for #204 - we will still need to do a bulk export of the current data to AirTables, which I would like to tackle next.


