### PR TITLE
Feature/210 email only sign up endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -190,6 +190,40 @@ API endpoints that Operation Code's Rails backend makes available to its React f
             errors: "Some error message"
         }
 
+## Email List Recipients | Create [/api/v1/email_list_recipients{?email}]
++ Parameters
+
+  + email (string, required) - The email address of the OC guest to be added to the OC's email list
+
+### Add a guest (non-user) to the OC's email list [POST]
+
+  + Request (application/json)
+
+      + Headers
+
+              Authorization: Bearer Access-Token
+
+      + Body
+
+                  {
+                      "email": "john@gmail.com",
+                  }
+
+  + Response 201 (application/json)
+
+      + Body
+
+              {
+                  "email": "john@gmail.com",
+                  "guest": true
+              }
+
+  + Response 422 (application/json)
+
+          {
+              errors: "Some error message"
+          }
+
 ## Event | Collection [/api/v1/events]
 
 ### List all Events [GET]

--- a/app/controllers/api/v1/email_list_recipients_controller.rb
+++ b/app/controllers/api/v1/email_list_recipients_controller.rb
@@ -1,0 +1,32 @@
+module Api
+  module V1
+    class EmailListRecipientsController < ApplicationController
+      def create
+        raise "Invalid email address: #{params[:email]}" unless valid_email?
+
+        AddUserToSendGridJob.perform_later(guest)
+
+        render json: { email: params[:email], guest: true }, status: :created
+      rescue StandardError => e
+        render json: { errors: e.message }, status: :unprocessable_entity
+      end
+
+    private
+
+      # Guest is a Struct.  ActiveJob does not support the passing of Structs
+      # as an argument. An ActiveJob::SerializationError < ArgumentError is raised.
+      #
+      # It does permit Arrays.  As such, the Struct is being passed within an Array.
+      #
+      # @see http://api.rubyonrails.org/classes/ActiveJob/SerializationError.html
+      #
+      def guest
+        [SendGridClient::Guest.user(params[:email])]
+      end
+
+      def valid_email?
+        params[:email] =~ User::VALID_EMAIL
+      end
+    end
+  end
+end

--- a/app/jobs/add_user_to_send_grid_job.rb
+++ b/app/jobs/add_user_to_send_grid_job.rb
@@ -2,6 +2,25 @@ class AddUserToSendGridJob < ApplicationJob
   queue_as :default
 
   def perform(user)
-    SendGridClient.new.add_user(user)
+    end_user = type_of_user(user)
+
+    SendGridClient.new.add_user(end_user)
+  end
+
+private
+
+  # ActiveJob does not support the passing of Structs as an argument.
+  # An ActiveJob::SerializationError < ArgumentError is raised.
+  #
+  # It does permit Arrays.  As such, a Struct can be passed within an Array.
+  #
+  # @see http://api.rubyonrails.org/classes/ActiveJob/SerializationError.html
+  #
+  def type_of_user(user)
+    if user.class == Array
+      user.first
+    else
+      user
+    end
   end
 end

--- a/app/lib/send_grid_client.rb
+++ b/app/lib/send_grid_client.rb
@@ -71,15 +71,19 @@ class SendGridClient
 
   def add_recipient(data)
     response = Response.new(add_recipient_request(data))
+
     Rails.logger.info("Response: #{response.body}")
     raise(SendGridClientError, response.body) unless response.successful?
+
     response.body['persisted_recipients']
   end
 
   def add_recipient_to_list(recipient_id)
     response = Response.new(add_recipient_to_list_request(recipient_id))
+
     Rails.logger.info("Response: #{response.body}")
     raise(SendGridClientError, response.body) unless response.successful?
+
     true
   end
 
@@ -89,7 +93,9 @@ class SendGridClient
 
   # The method chains in these request methods represents the path of the API request.
   # SendGrid calls this it's Fluent Interface
-  # https://github.com/sendgrid/sendgrid-ruby#general-v3-web-api-usage-with-fluent-interface
+  #
+  # @see https://github.com/sendgrid/sendgrid-ruby#general-v3-web-api-usage-with-fluent-interface
+  #
   def add_recipient_request(data)
     @sendgrid.client.contactdb.recipients.post(request_body: [data])
   end

--- a/app/lib/send_grid_client/guest.rb
+++ b/app/lib/send_grid_client/guest.rb
@@ -1,0 +1,25 @@
+# The OC has end users that would like to be on our emailing list; however,
+# have not committed to creating a User account with us, yet.
+#
+# This class allows us to create Structs for these 'guests', that respond
+# identically to a User object, within the SendGridClient class.
+#
+class SendGridClient::Guest
+  Visitor = Struct.new(:id, :email, :first_name, :last_name) do
+    def attributes
+      to_h.as_json
+    end
+  end
+
+  # Creates a user-like Struct, to represent an OC guest.
+  #
+  # Defaults the :id attribute to 'guest-id', as their is no database id;
+  # however, the id needs to be logged for debugging in the SendGridClient.
+  #
+  # @param email_address [String] A string of the guest's email address
+  # @return [Struct] A user-like struct
+  #
+  def self.user(email_address)
+    Visitor.new('guest-id', email_address, '', '')
+  end
+end

--- a/app/lib/send_grid_client/response.rb
+++ b/app/lib/send_grid_client/response.rb
@@ -19,8 +19,10 @@ class SendGridClient::Response
 
   # Some requests don't return a body so we default to just checking
   # the status code
+  #
   def successful_error_count
     return true if body.blank?
+
     body['error_count'] == 0
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,12 +17,18 @@ class User < ApplicationRecord
   # These attributes are what we send to sendgrid as custom fields
   SENDGRID_ATTRIBUTES = %w[first_name last_name email]
 
+  # This regex comes from the `validates_format_of` Rails docs
+  #
+  # @see http://api.rubyonrails.org/classes/ActiveModel/Validations/HelperMethods.html#method-i-validates_format_of
+  #
+  VALID_EMAIL = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+
   after_create :welcome_user
   before_save :geocode, if: ->(v) { v.zip.present? && v.zip_changed? }
   before_save :upcase_state
   before_save :downcase_email
 
-  validates_format_of :email, :with => /\A.*@.*\z/
+  validates_format_of :email, :with => VALID_EMAIL
   validates :email, uniqueness: true
 
   has_many :requests

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,14 +20,14 @@ Rails.application.routes.draw do
       resources :code_schools do
         resources :locations
       end
-      resources :scholarships, only: [:index, :show]
-      resources :scholarship_applications, only: :create
       resources :events, only: :index
       resources :mentors, only: [:index, :create, :show]
       resources :requests, only: [:index, :create, :show, :update]
       resources :resources, only: [:index, :create, :show, :update, :destroy] do
         resources :votes, only: [:create, :destroy]
       end
+      resources :scholarships, only: [:index, :show]
+      resources :scholarship_applications, only: :create
       resources :services, only: :index
       resources :slack_users, only: :create
       resources :tags, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       resources :code_schools do
         resources :locations
       end
+      resources :email_list_recipients, only: :create
       resources :events, only: :index
       resources :mentors, only: [:index, :create, :show]
       resources :requests, only: [:index, :create, :show, :update]

--- a/test/controllers/api/v1/email_list_recipients_controller_test.rb
+++ b/test/controllers/api/v1/email_list_recipients_controller_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class Api::V1::EmailListRecipientsControllerTest < ActionDispatch::IntegrationTest
+  test ":create with a valid email address renders the guest's email address and guest: true" do
+    stub_send_grid_job
+
+    post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
+
+    assert JSON.parse(response.body) == { "email" => valid_email, "guest" => true }
+  end
+
+  test ":create with a valid email address, responds with a status of 201 (created)" do
+    stub_send_grid_job
+
+    post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
+
+    assert response.status == 201
+  end
+
+  test ":create with a valid email address, it calls the AddUserToSendGridJob" do
+    guest = [SendGridClient::Guest.user(valid_email)]
+
+    AddUserToSendGridJob.expects(:perform_later).with(guest)
+
+    post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
+  end
+
+  test ":create with a invalid email address, renders an error message" do
+    post api_v1_email_list_recipients_path, params: { email: invalid_email }, as: :json
+
+    assert JSON.parse(response.body) == { "errors" => "Invalid email address: #{invalid_email}" }
+  end
+
+  test ":create with an invalid email address, it does not call the AddUserToSendGridJob" do
+    0.times { AddUserToSendGridJob.expects(:perform_later) }
+
+    post api_v1_email_list_recipients_path, params: { email: invalid_email }, as: :json
+  end
+end
+
+def stub_send_grid_job
+  AddUserToSendGridJob.stubs(:perform_later).returns(true)
+end
+
+def valid_email
+  "john@gmail.com"
+end
+
+def invalid_email
+  "johngmail.com"
+end

--- a/test/jobs/add_user_to_send_grid_job_test.rb
+++ b/test/jobs/add_user_to_send_grid_job_test.rb
@@ -3,7 +3,9 @@ require 'test_helper'
 class AddUserToSendGridJobTest < ActiveJob::TestCase
   test 'it adds a user to send grid' do
     user = FactoryGirl.build(:user)
+
     SendGridClient.any_instance.expects(:add_user).with(user)
+
     AddUserToSendGridJob.perform_now(user)
   end
 end

--- a/test/jobs/add_user_to_send_grid_job_test.rb
+++ b/test/jobs/add_user_to_send_grid_job_test.rb
@@ -8,4 +8,16 @@ class AddUserToSendGridJobTest < ActiveJob::TestCase
 
     AddUserToSendGridJob.perform_now(user)
   end
+
+  test "with a user-like Struct wrapped in an array, it adds the Struct user to send grid" do
+    guest = [SendGridClient::Guest.user(valid_email)]
+
+    SendGridClient.any_instance.expects(:add_user).with(guest.first)
+
+    AddUserToSendGridJob.perform_now(guest)
+  end
+end
+
+def valid_email
+  "john@gmail.com"
 end

--- a/test/lib/send_grid_client/guest_test.rb
+++ b/test/lib/send_grid_client/guest_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class SendGridClient::GuestTest < ActiveSupport::TestCase
+  test "#user creates a user-like Struct, to represent an OC guest" do
+    guest = SendGridClient::Guest.user(valid_email)
+
+    assert guest.to_s.include?("struct")
+  end
+
+  test "#user creates an :id method that defaults to 'guest-id'" do
+    guest = SendGridClient::Guest.user(valid_email)
+
+    assert guest.id == 'guest-id'
+  end
+
+  test "#user creates an :email method that is set to the passed email address" do
+    guest = SendGridClient::Guest.user(valid_email)
+
+    assert guest.email == valid_email
+  end
+
+  test "#attributes returns JSON for the Struct's id, first_name, last_name, and email" do
+    guest = SendGridClient::Guest.user(valid_email)
+
+    assert guest.attributes == {
+      "id" => "guest-id",
+      "email" => valid_email,
+      "first_name" => "",
+      "last_name" => ""
+    }
+  end
+end
+
+def valid_email
+  "john@gmail.com"
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -154,4 +154,20 @@ class UserTest < ActiveSupport::TestCase
     results = User.count_by_state ''
     assert_equal 0, results
   end
+
+  test 'VALID_EMAIL regex ensures valid formatting' do
+    # valid email formats
+    assert "john@gmail.com" =~ User::VALID_EMAIL
+    assert "j@example.com" =~ User::VALID_EMAIL
+    assert "jack@anything.io" =~ User::VALID_EMAIL
+    assert "jack@anything.org" =~ User::VALID_EMAIL
+    assert "jack@anything.net" =~ User::VALID_EMAIL
+    assert "jack@anything.whatever" =~ User::VALID_EMAIL
+
+    # invalid email formats
+    refute "johngmail.com" =~ User::VALID_EMAIL
+    refute "john#gmail.com" =~ User::VALID_EMAIL
+    refute "john@gmail" =~ User::VALID_EMAIL
+    refute "@example.com" =~ User::VALID_EMAIL
+  end
 end


### PR DESCRIPTION
# Description of changes
We want to allow someone to sign up for our email list, without having to become a full member of Operation Code (i.e. a "guest").  

This PR:
- [x] adds an API endpoint, which takes a guest's email address, and sends it to the existing Sendgrid email list
- [x] adds test coverage for new functionality 
- [x] updates our Apiary API docs with the new endpoint
- [x] as a citizen of the codebase, makes some styling updates for increased readability

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #210 

### Associated frontend issue

https://github.com/OperationCode/operationcode_frontend/issues/745