### PR TITLE
bug/fixes 'add guest to sendgrid contact list' endpoint 

### DIFF
--- a/app/controllers/api/v1/email_list_recipients_controller.rb
+++ b/app/controllers/api/v1/email_list_recipients_controller.rb
@@ -4,7 +4,7 @@ module Api
       def create
         raise "Invalid email address: #{permitted_params[:email]}" unless valid_email?
 
-        AddUserToSendGridJob.perform_later(guest)
+        AddUserToSendGridJob.perform_later(nil, guest_email: permitted_params[:email])
 
         render json: { email: permitted_params[:email], guest: true }, status: :created
       rescue StandardError => e
@@ -15,17 +15,6 @@ module Api
 
       def permitted_params
         params.permit(:email)
-      end
-
-      # Guest is a Struct.  ActiveJob does not support the passing of Structs
-      # as an argument. An ActiveJob::SerializationError < ArgumentError is raised.
-      #
-      # It does permit Arrays.  As such, the Struct is being passed within an Array.
-      #
-      # @see http://api.rubyonrails.org/classes/ActiveJob/SerializationError.html
-      #
-      def guest
-        [SendGridClient::Guest.user(permitted_params[:email])]
       end
 
       def valid_email?

--- a/app/jobs/add_user_to_send_grid_job.rb
+++ b/app/jobs/add_user_to_send_grid_job.rb
@@ -1,26 +1,48 @@
 class AddUserToSendGridJob < ApplicationJob
   queue_as :default
 
-  def perform(user)
-    end_user = type_of_user(user)
+  # Adds the passed user, or guest, to our Contact List in SendGrid.
+  #
+  # @param user [User] An ActiveRecord instance of the User class
+  # @param guest_email [String] A string of the guest's email
+  #   A guest_email is only provided when we do not have a User object,
+  #   and vice versa.
+  #
+  def perform(user, guest_email: nil)
+    end_user = type_of_user(user, guest_email)
 
     SendGridClient.new.add_user(end_user)
   end
 
 private
 
-  # ActiveJob does not support the passing of Structs as an argument.
-  # An ActiveJob::SerializationError < ArgumentError is raised.
+  # Determines if the end user being added is a persisted User,
+  # or a guest.
   #
-  # It does permit Arrays.  As such, a Struct can be passed within an Array.
+  # This is necessary because ActiveJob does not support the passing
+  # of Structs as an argument. An ActiveJob::SerializationError < ArgumentError
+  # is raised.
   #
+  # @param user [User] An ActiveRecord instance of the User class
+  # @param guest_email [String] A string of the guest's email
+  # @return [User] Returns the passed User, if user is provided
+  # @return [Struct] Returns a user-like Struct if guest_email is provided
   # @see http://api.rubyonrails.org/classes/ActiveJob/SerializationError.html
   #
-  def type_of_user(user)
-    if user.class == Array
-      user.first
+  def type_of_user(user, guest_email)
+    if guest_email && user.nil?
+      guest(guest_email)
     else
       user
     end
+  end
+
+  # Creates a user-like Struct, representing a guest.
+  #
+  # @param guest_email [String] A string of the guest's email
+  # @return [Struct] Returns a user-like Struct
+  #
+  def guest(guest_email)
+    SendGridClient::Guest.user(guest_email)
   end
 end

--- a/test/controllers/api/v1/email_list_recipients_controller_test.rb
+++ b/test/controllers/api/v1/email_list_recipients_controller_test.rb
@@ -17,10 +17,8 @@ class Api::V1::EmailListRecipientsControllerTest < ActionDispatch::IntegrationTe
     assert response.status == 201
   end
 
-  test ":create with a valid email address, it calls the AddUserToSendGridJob" do
-    guest = [SendGridClient::Guest.user(valid_email)]
-
-    AddUserToSendGridJob.expects(:perform_later).with(guest)
+  test ":create with a valid email address, and a nil user, it calls the AddUserToSendGridJob" do
+    AddUserToSendGridJob.expects(:perform_later).with(nil, guest_email: valid_email)
 
     post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
   end

--- a/test/jobs/add_user_to_send_grid_job_test.rb
+++ b/test/jobs/add_user_to_send_grid_job_test.rb
@@ -9,12 +9,20 @@ class AddUserToSendGridJobTest < ActiveJob::TestCase
     AddUserToSendGridJob.perform_now(user)
   end
 
-  test "with a user-like Struct wrapped in an array, it adds the Struct user to send grid" do
-    guest = [SendGridClient::Guest.user(valid_email)]
+  test "with a guest_email, and no user, it adds the Struct user to send grid" do
+    guest = SendGridClient::Guest.user(valid_email)
 
-    SendGridClient.any_instance.expects(:add_user).with(guest.first)
+    SendGridClient.any_instance.expects(:add_user).with(guest)
 
-    AddUserToSendGridJob.perform_now(guest)
+    AddUserToSendGridJob.perform_now(nil, guest_email: valid_email)
+  end
+
+  test "with a guest_email, and a valid user, it adds the User to send grid" do
+    user = FactoryGirl.build(:user)
+
+    SendGridClient.any_instance.expects(:add_user).with(user)
+
+    AddUserToSendGridJob.perform_now(user, guest_email: valid_email)
   end
 end
 


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
### TL;DR
- Updates SendGrid background job to receive valid argument
- Permits `email` param in `email_list_recipients_controller`

### Background
All of the tests were giving false positives, because in testing, `perform_now` is called in the background.

Also, during manual testing, `perform_now` was being used.

The catch is, `perform_later` does not accept an array wrapped Struct as an argument, despite the fact that it allows arrays.

As such, this logic was migrated from the controller, to the job itself.

Now the job is receiving a string as as an arg, which `perform_later` does accept.

Also, the `email` param in the new `email_list_recipients_controller` was not being explicitly permitted.  This was not causing any issues, but is a best practice that I initially overlooked.
