### PR TITLE
bug/guest emails not being added to SendGrid

### DIFF
--- a/app/controllers/api/v1/email_list_recipients_controller.rb
+++ b/app/controllers/api/v1/email_list_recipients_controller.rb
@@ -4,7 +4,7 @@ module Api
       def create
         raise "Invalid email address: #{permitted_params[:email]}" unless valid_email?
 
-        AddUserToSendGridJob.perform_later(nil, guest_email: permitted_params[:email])
+        AddUserToSendGridJob.perform_later(nil, permitted_params[:email])
 
         render json: { email: permitted_params[:email], guest: true }, status: :created
       rescue StandardError => e

--- a/app/jobs/add_user_to_send_grid_job.rb
+++ b/app/jobs/add_user_to_send_grid_job.rb
@@ -8,7 +8,7 @@ class AddUserToSendGridJob < ApplicationJob
   #   A guest_email is only provided when we do not have a User object,
   #   and vice versa.
   #
-  def perform(user, guest_email: nil)
+  def perform(user, guest_email = nil)
     end_user = type_of_user(user, guest_email)
 
     SendGridClient.new.add_user(end_user)

--- a/test/controllers/api/v1/email_list_recipients_controller_test.rb
+++ b/test/controllers/api/v1/email_list_recipients_controller_test.rb
@@ -18,7 +18,7 @@ class Api::V1::EmailListRecipientsControllerTest < ActionDispatch::IntegrationTe
   end
 
   test ":create with a valid email address, and a nil user, it calls the AddUserToSendGridJob" do
-    AddUserToSendGridJob.expects(:perform_later).with(nil, guest_email: valid_email)
+    AddUserToSendGridJob.expects(:perform_later).with(nil, valid_email)
 
     post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
   end

--- a/test/jobs/add_user_to_send_grid_job_test.rb
+++ b/test/jobs/add_user_to_send_grid_job_test.rb
@@ -14,7 +14,7 @@ class AddUserToSendGridJobTest < ActiveJob::TestCase
 
     SendGridClient.any_instance.expects(:add_user).with(guest)
 
-    AddUserToSendGridJob.perform_now(nil, guest_email: valid_email)
+    AddUserToSendGridJob.perform_now(nil, valid_email)
   end
 
   test "with a guest_email, and a valid user, it adds the User to send grid" do
@@ -22,7 +22,7 @@ class AddUserToSendGridJobTest < ActiveJob::TestCase
 
     SendGridClient.any_instance.expects(:add_user).with(user)
 
-    AddUserToSendGridJob.perform_now(user, guest_email: valid_email)
+    AddUserToSendGridJob.perform_now(user, valid_email)
   end
 end
 


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Sidekiq appears to not support key word arguments:  https://github.com/mperham/sidekiq/issues/2372

As such, this PR changes the key word arguments to positional arguments.

After testing this in local development, with a temporary SendGrid API key, I was able to: 
- run the back and frontend repos together
- submit an email address in the UI
- confirm the email address was added to our SendGrid marketing contacts list
- confirm no sidekiq errors in the server logs

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #222 
