### PR TITLE
Bug/225 sidekiq errors in prod for guest sendgrid contacts

### DIFF
--- a/app/controllers/api/v1/email_list_recipients_controller.rb
+++ b/app/controllers/api/v1/email_list_recipients_controller.rb
@@ -4,7 +4,7 @@ module Api
       def create
         raise "Invalid email address: #{permitted_params[:email]}" unless valid_email?
 
-        AddUserToSendGridJob.perform_later(nil, permitted_params[:email])
+        AddGuestToSendGridJob.perform_later(permitted_params[:email])
 
         render json: { email: permitted_params[:email], guest: true }, status: :created
       rescue StandardError => e

--- a/app/jobs/add_guest_to_send_grid_job.rb
+++ b/app/jobs/add_guest_to_send_grid_job.rb
@@ -1,0 +1,22 @@
+class AddGuestToSendGridJob < ApplicationJob
+  queue_as :default
+
+  # Adds the passed guest to our Contact List in SendGrid.
+  #
+  # @param guest_email [String] A string of the guest's email
+  #
+  def perform(guest_email)
+    SendGridClient.new.add_user guest(guest_email)
+  end
+
+private
+
+  # Creates a user-like Struct, representing a guest.
+  #
+  # @param guest_email [String] A string of the guest's email
+  # @return [Struct] Returns a user-like Struct
+  #
+  def guest(guest_email)
+    SendGridClient::Guest.user(guest_email)
+  end
+end

--- a/app/jobs/add_user_to_send_grid_job.rb
+++ b/app/jobs/add_user_to_send_grid_job.rb
@@ -1,48 +1,7 @@
 class AddUserToSendGridJob < ApplicationJob
   queue_as :default
 
-  # Adds the passed user, or guest, to our Contact List in SendGrid.
-  #
-  # @param user [User] An ActiveRecord instance of the User class
-  # @param guest_email [String] A string of the guest's email
-  #   A guest_email is only provided when we do not have a User object,
-  #   and vice versa.
-  #
-  def perform(user, guest_email = nil)
-    end_user = type_of_user(user, guest_email)
-
-    SendGridClient.new.add_user(end_user)
-  end
-
-private
-
-  # Determines if the end user being added is a persisted User,
-  # or a guest.
-  #
-  # This is necessary because ActiveJob does not support the passing
-  # of Structs as an argument. An ActiveJob::SerializationError < ArgumentError
-  # is raised.
-  #
-  # @param user [User] An ActiveRecord instance of the User class
-  # @param guest_email [String] A string of the guest's email
-  # @return [User] Returns the passed User, if user is provided
-  # @return [Struct] Returns a user-like Struct if guest_email is provided
-  # @see http://api.rubyonrails.org/classes/ActiveJob/SerializationError.html
-  #
-  def type_of_user(user, guest_email)
-    if guest_email && user.nil?
-      guest(guest_email)
-    else
-      user
-    end
-  end
-
-  # Creates a user-like Struct, representing a guest.
-  #
-  # @param guest_email [String] A string of the guest's email
-  # @return [Struct] Returns a user-like Struct
-  #
-  def guest(guest_email)
-    SendGridClient::Guest.user(guest_email)
+  def perform(user)
+    SendGridClient.new.add_user(user)
   end
 end

--- a/test/controllers/api/v1/email_list_recipients_controller_test.rb
+++ b/test/controllers/api/v1/email_list_recipients_controller_test.rb
@@ -17,27 +17,27 @@ class Api::V1::EmailListRecipientsControllerTest < ActionDispatch::IntegrationTe
     assert response.status == 201
   end
 
-  test ":create with a valid email address, and a nil user, it calls the AddUserToSendGridJob" do
-    AddUserToSendGridJob.expects(:perform_later).with(nil, valid_email)
+  test ":create with a valid email address calls the AddGuestToSendGridJob" do
+    AddGuestToSendGridJob.expects(:perform_later).with(valid_email)
 
     post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
   end
 
-  test ":create with a invalid email address, renders an error message" do
+  test ":create with a invalid email address renders an error message" do
     post api_v1_email_list_recipients_path, params: { email: invalid_email }, as: :json
 
     assert JSON.parse(response.body) == { "errors" => "Invalid email address: #{invalid_email}" }
   end
 
-  test ":create with an invalid email address, it does not call the AddUserToSendGridJob" do
-    0.times { AddUserToSendGridJob.expects(:perform_later) }
+  test ":create with an invalid email address does not call the AddGuestToSendGridJob" do
+    0.times { AddGuestToSendGridJob.expects(:perform_later) }
 
     post api_v1_email_list_recipients_path, params: { email: invalid_email }, as: :json
   end
 end
 
 def stub_send_grid_job
-  AddUserToSendGridJob.stubs(:perform_later).returns(true)
+  AddGuestToSendGridJob.stubs(:perform_later).returns(true)
 end
 
 def valid_email

--- a/test/jobs/add_guest_to_send_grid_job_test.rb
+++ b/test/jobs/add_guest_to_send_grid_job_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class AddGuestToSendGridJobTest < ActiveJob::TestCase
+  test "it adds the guest to send grid" do
+    guest = SendGridClient::Guest.user(valid_email)
+
+    SendGridClient.any_instance.expects(:add_user).with(guest)
+
+    AddGuestToSendGridJob.perform_now(valid_email)
+  end
+end
+
+def valid_email
+  "john@gmail.com"
+end

--- a/test/jobs/add_user_to_send_grid_job_test.rb
+++ b/test/jobs/add_user_to_send_grid_job_test.rb
@@ -8,24 +8,4 @@ class AddUserToSendGridJobTest < ActiveJob::TestCase
 
     AddUserToSendGridJob.perform_now(user)
   end
-
-  test "with a guest_email, and no user, it adds the Struct user to send grid" do
-    guest = SendGridClient::Guest.user(valid_email)
-
-    SendGridClient.any_instance.expects(:add_user).with(guest)
-
-    AddUserToSendGridJob.perform_now(nil, valid_email)
-  end
-
-  test "with a guest_email, and a valid user, it adds the User to send grid" do
-    user = FactoryGirl.build(:user)
-
-    SendGridClient.any_instance.expects(:add_user).with(user)
-
-    AddUserToSendGridJob.perform_now(user, valid_email)
-  end
-end
-
-def valid_email
-  "john@gmail.com"
 end


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Due to the Sidekiq errors outlined in issue #225 , this PR creates a dedicated background job for adding a guest user to SendGrid's contacts list.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #225 
