### PR TITLE
bug/addresses flakey controller test

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 COMPOSE_PROJECT_NAME=operationcodebackend
 REDIS_URL=redis://redis:6379/0
 RAILS_ENV=development
+POSTGRES_HOST=operationcode-psql

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,15 +7,6 @@ require 'sidekiq'
 #
 Sidekiq.configure_server do |config|
   ENV['DATABASE_URL'] = ENV['POSTGRES_HOST'].present? ? ENV['POSTGRES_HOST'] : 'operationcode-psql'
-  database_url = ENV['DATABASE_URL']
-
-  if database_url
-    ENV['DATABASE_URL'] = "#{database_url}?pool=25"
-    ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
-    # Note that as of Rails 4.1 the `establish_connection` method requires
-    # the database_url be passed in as an argument. Like this:
-    # ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
-  end
 
   Rails.logger = Sidekiq::Logging.logger
   ActiveRecord::Base.logger = Sidekiq::Logging.logger

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,6 +7,15 @@ require 'sidekiq'
 #
 Sidekiq.configure_server do |config|
   ENV['DATABASE_URL'] = ENV['POSTGRES_HOST'].present? ? ENV['POSTGRES_HOST'] : 'operationcode-psql'
+  database_url = ENV['DATABASE_URL']
+
+  if database_url
+    ENV['DATABASE_URL'] = "#{database_url}?pool=25"
+    ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
+    # Note that as of Rails 4.1 the `establish_connection` method requires
+    # the database_url be passed in as an argument. Like this:
+    # ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
+  end
 
   Rails.logger = Sidekiq::Logging.logger
   ActiveRecord::Base.logger = Sidekiq::Logging.logger

--- a/test/controllers/api/v1/locations_controller_test.rb
+++ b/test/controllers/api/v1/locations_controller_test.rb
@@ -107,7 +107,7 @@ class Api::V1::LocationsControllerTest < ActionDispatch::IntegrationTest
     school = create(:code_school)
     location = create(:location, code_school: school)
 
-    delete api_v1_code_school_location_path(school, 1), headers: @headers
+    delete api_v1_code_school_location_path(school, location.id + 1000), headers: @headers
 
     assert_response :unprocessable_entity
   end


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
As described in issue #227 , a test in the `locations_controller_test` randomly fails, causing random build failures. 

This was happening because _sometimes_ there would be a `Location` record in the database equal to the hardcoded id of `1`.  When this happened, the record was being successfully deleted, thusly yielding a status of `200`, instead of the expected `422`.

By dynamically grabbing the `Location`s id, and adding 1000 to it, we ensure the passed location ID is not in the test db.

This also addresses a database issue in the local dev server logs, where an `.env` variable needed to be set.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #227 
