### PR TITLE
force sidekiq to fallback to config/database.yml credentials

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,7 +6,7 @@ require 'sidekiq'
 # @see https://github.com/mperham/sidekiq/wiki/Advanced-Options#rails-32-and-newer
 #
 Sidekiq.configure_server do |config|
-  ENV['DATABASE_URL'] = ENV['POSTGRES_HOST'].present? ? ENV['POSTGRES_HOST'] : 'operationcode-psql'
+  #ENV['DATABASE_URL'] = ENV['POSTGRES_HOST'].present? ? ENV['POSTGRES_HOST'] : 'operationcode-psql'
 
   Rails.logger = Sidekiq::Logging.logger
   ActiveRecord::Base.logger = Sidekiq::Logging.logger


### PR DESCRIPTION
# Description of changes
This PR prevents the defining of the environment variable `DATABASE_URL`. Leaving `DATABASE_URL` undefined forces Sidekiq to fallback to using `config/database.yml` for the Postgres configuration. Without this change, `DATABASE_URL` evaluates to an invalid URL format and Sidekiq attempts to connect to a database named `operationcode-psql` which does not exist.

# Issue Resolved
Sidekiq database connection failure