### PR TITLE
Add is_mooc to CodeSchools and create get_moocs endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ test: bg
 bundle:
 	docker-compose run ${RAILS_CONTAINER} bash -c 'cd /app && bundle'
 
+.PHONY: db_drop_and_create_and_migrate
+db_drop_and_create_and_migrate:
+	docker-compose run ${RAILS_CONTAINER} rake db:drop db:create db:migrate
+
 setup: build db_create db_migrate
 
 publish: build

--- a/apiary.apib
+++ b/apiary.apib
@@ -19,6 +19,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                 "full_time": true,
                 "hardware_included": false,
                 "has_online": false,
+                "is_mooc": false,
                 "online_only": false,
                 "locations":  [
                       {
@@ -39,7 +40,42 @@ API endpoints that Operation Code's Rails backend makes available to its React f
             },
         ]
 
-## CodeSchool | Create [/api/v1/code_schools{?name,url,logo,full_time,hardware_included,has_online,online_only,notes}]
+## MOOC CodeSchool | Collection [/api/v1/code_schools/get_moocs]
+
+### List all MOOCS [GET]
+
++ Response 200 (application/json)
+
+        [
+            {
+                "name": "Galvanize",
+                "url": "https://new.galvanize.com", "logo": "https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/galvanize.jpg",
+                "logo": "https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images/codeSchoolLogos/DPL_logo.png",
+                "full_time": true,
+                "hardware_included": false,
+                "has_online": false,
+                "is_mooc": true,
+                "online_only": false,
+                "locations":  [
+                      {
+                          "va_accepted": false,
+                          "address1": "44 Tehama Street",
+                          "city": "San Francisco",
+                          "state": "CA",
+                          "zip": 94015
+                      },
+                      {
+                          "va_accepted": true,
+                          "address1": "1062 Delaware Street",
+                          "city": "Denver",
+                          "state": "CO",
+                          "zip": 80204
+                      },
+                  ]
+            },
+        ]
+
+## CodeSchool | Create [/api/v1/code_schools{?name,url,logo,full_time,hardware_included,has_online,online_only,notes,is_mooc}]
 + Parameters
 
     + name (string, required) - The CodeSchool's name
@@ -50,6 +86,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
     + has_online (boolean, required) - Does the CodeSchool have an online component
     + online_only (boolean, required) - Is the CodeSchool online only?
     + notes (text, optional) - Any additional information about the CodeSchool
+    + is_mooc (boolean, optional) - Is this a MOOC?
 
 ### Create a CodeSchool Member [POST]
 
@@ -69,7 +106,8 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                       "full_time": "false",
                       "hardware_included": "false",
                       "has_online": "true",
-                      "online_only": "false"
+                      "online_only": "false",
+                      "is_mooc": "false"
                       }
                   }
 
@@ -108,6 +146,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
             "created_at": "2017-09-26T06:54:58.607Z",
             "updated_at": "2017-09-26T06:54:58.607Z",
             "notes": null
+            "is_mooc": "false"
         }
 
 + Response 404 (application/json)
@@ -146,7 +185,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                   errors: "Some error message"
               }
 
-## CodeSchool | Update [/api/v1/code_schools/{code_school_id}{?name,url,logo,full_time,hardware_included,has_online,online_only,notes}]
+## CodeSchool | Update [/api/v1/code_schools/{code_school_id}{?name,url,logo,full_time,hardware_included,has_online,online_only,notes,is_mooc}]
 
 + Parameters
 
@@ -158,6 +197,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
     + has_online (boolean, required) - Does the CodeSchool have an online component
     + online_only (boolean, required) - Is the CodeSchool online only?
     + notes (text, optional) - Any additional information about the CodeSchool
+    + is_mooc (boolean, optional) - Is the school a MOOC?
 
 ### Update an Existing CodeSchool [PUT]
 
@@ -746,7 +786,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
         {
             errors: "Some error message"
         }
-        
+
 ## Scholarships | Collection [/api/v1/scholarships]
 
 ### List All Scholarships Available [GET]
@@ -819,7 +859,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
 
             {
                 "user_id": 1234,
-                "scholarship_application": "Scholarship for kids who want to learn how to program", 
+                "scholarship_application": "Scholarship for kids who want to learn how to program",
                 "reason": "I want to go to college",
                 "terms_accepted": true,
                 "scholarship_id":  4
@@ -830,7 +870,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
     + Body
 
             {
-                redirect_to: '/success'                  
+                redirect_to: '/success'
             }
 
 + Response 400 (application/json)
@@ -841,7 +881,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                 errors: "Some error message"
             }
 
-        
+
 ## Slack User | Invite [/api/v1/slack_users]
 
 ### Invite a User to Slack [POST]
@@ -1109,7 +1149,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                 first_name: "Mike",
                 last_name: "Johnson",
                 email: "dreams@operationcode.org",
-                zip: "80020",            
+                zip: "80020",
                 mentor: "true"
             }
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -40,9 +40,9 @@ API endpoints that Operation Code's Rails backend makes available to its React f
             },
         ]
 
-## MOOC CodeSchool | Collection [/api/v1/code_schools/get_moocs]
+## CodeSchool | Collection of MOOCs [/api/v1/code_schools/get_moocs]
 
-### List all MOOCS [GET]
+### Collection of Code Schools offering Massive Open Online Courses
 
 + Response 200 (application/json)
 
@@ -86,7 +86,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
     + has_online (boolean, required) - Does the CodeSchool have an online component
     + online_only (boolean, required) - Is the CodeSchool online only?
     + notes (text, optional) - Any additional information about the CodeSchool
-    + is_mooc (boolean, optional) - Is this a MOOC?
+    + is_mooc (boolean, optional) - Does the CodeSchool offer Massive Open Online Courses?
 
 ### Create a CodeSchool Member [POST]
 
@@ -197,7 +197,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
     + has_online (boolean, required) - Does the CodeSchool have an online component
     + online_only (boolean, required) - Is the CodeSchool online only?
     + notes (text, optional) - Any additional information about the CodeSchool
-    + is_mooc (boolean, optional) - Is the school a MOOC?
+    + is_mooc (boolean, optional) - Does the CodeSchool offer Massive Open Online Courses?
 
 ### Update an Existing CodeSchool [PUT]
 

--- a/app/controllers/api/v1/code_schools_controller.rb
+++ b/app/controllers/api/v1/code_schools_controller.rb
@@ -42,10 +42,19 @@ module Api
         end
       end
 
+      def get_moocs
+        mooc_school = CodeSchool.where(is_mooc: "true")
+        if mooc_school
+          render json: mooc_school
+        else
+          render json: { error: 'No such record' }, status: :not_found
+        end
+      end
+
       private
 
       def code_school_params
-        params.require(:code_school).permit(:name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only)
+        params.require(:code_school).permit(:name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only, :is_mooc)
       end
     end
   end

--- a/app/controllers/api/v1/code_schools_controller.rb
+++ b/app/controllers/api/v1/code_schools_controller.rb
@@ -42,13 +42,9 @@ module Api
         end
       end
 
-      def get_moocs
-        mooc_school = CodeSchool.where(is_mooc: "true")
-        if mooc_school
-          render json: mooc_school
-        else
-          render json: { error: 'No such record' }, status: :not_found
-        end
+      def moocs
+        mooc_schools = CodeSchool.where(is_mooc: true)
+        render json: mooc_schools
       end
 
       private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,9 +17,12 @@ Rails.application.routes.draw do
       get '/users/by_location', to: 'users#by_location'
       post '/users/profile/verify', to: 'users#verify'
 
+      get 'code_schools/get_moocs', to: 'code_schools#get_moocs'
+
       resources :code_schools do
         resources :locations
       end
+
       resources :email_list_recipients, only: :create
       resources :events, only: :index
       resources :mentors, only: [:index, :create, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
       get '/users/by_location', to: 'users#by_location'
       post '/users/profile/verify', to: 'users#verify'
 
-      get 'code_schools/get_moocs', to: 'code_schools#get_moocs'
+      get 'code_schools/moocs', to: 'code_schools#moocs'
 
       resources :code_schools do
         resources :locations

--- a/db/migrate/20180111022931_add_is_mooc_to_code_schools.rb
+++ b/db/migrate/20180111022931_add_is_mooc_to_code_schools.rb
@@ -1,0 +1,5 @@
+class AddIsMoocToCodeSchools < ActiveRecord::Migration[5.0]
+  def change
+    add_column :code_schools, :is_mooc, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,11 +44,11 @@ ActiveRecord::Schema.define(version: 20180111022931) do
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
     t.string   "source_id"
-    t.string   "source"
+    t.string   "source_type"
     t.datetime "source_updated"
     t.string   "group"
-    t.index ["source"], name: "index_events_on_source", using: :btree
     t.index ["source_id"], name: "index_events_on_source_id", using: :btree
+    t.index ["source_type"], name: "index_events_on_source_type", using: :btree
   end
 
   create_table "git_hub_statistics", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171022215418) do
+ActiveRecord::Schema.define(version: 20180111022931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20171022215418) do
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
     t.text     "notes"
+    t.boolean  "is_mooc"
   end
 
   create_table "events", force: :cascade do |t|
@@ -43,11 +44,11 @@ ActiveRecord::Schema.define(version: 20171022215418) do
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
     t.string   "source_id"
-    t.string   "source_type"
+    t.string   "source"
     t.datetime "source_updated"
     t.string   "group"
+    t.index ["source"], name: "index_events_on_source", using: :btree
     t.index ["source_id"], name: "index_events_on_source_id", using: :btree
-    t.index ["source_type"], name: "index_events_on_source_type", using: :btree
   end
 
   create_table "git_hub_statistics", force: :cascade do |t|

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -59,17 +59,17 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     assert_response :missing
   end
 
-  test ":get_moocs returns schools with is_Mooc set to true" do
-    @school.is_mooc = "true"
+  test ":moocs returns schools with is_mooc is true" do
+    @school.is_mooc = true
     @school.save
-    get  api_v1_code_schools_get_moocs_path, as: :json
+    get  api_v1_code_schools_moocs_path, as: :json
     assert_equal JSON.parse(response.body)[0]["name"], "CoderSchool"
   end
 
-  test ":get_moocs does not return school when is_Mooc is false" do
-    @school.is_mooc = "false"
+  test ":moocs does not return school when is_mooc is false" do
+    @school.is_mooc = false
     @school.save
-    get  api_v1_code_schools_get_moocs_path, as: :json
-    assert_equal JSON.parse(response.body), []
+    get  api_v1_code_schools_moocs_path, as: :json
+    assert_equal response_json, []
   end
 end

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -38,7 +38,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     assert_response :missing
   end
 
-  test ":show works for a valid record"do
+  test ":show works for a valid record" do
     get api_v1_code_school_path(@school), as: :json
     assert_response :ok
   end
@@ -62,14 +62,14 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
   test ":get_moocs returns schools with is_Mooc set to true" do
     @school.is_mooc = "true"
     @school.save
-    get  api_v1_code_schools_get_moocs, as: :json
-    assert_equal JSON.parse(response.body)["name"], "CoderSchool"
+    get  api_v1_code_schools_get_moocs_path, as: :json
+    assert_equal JSON.parse(response.body)[0]["name"], "CoderSchool"
   end
 
   test ":get_moocs does not return school when is_Mooc is false" do
     @school.is_mooc = "false"
     @school.save
-    get  api_v1_code_schools_get_moocs, as: :json
-    assert_response :missing
+    get  api_v1_code_schools_get_moocs_path, as: :json
+    assert_equal JSON.parse(response.body), []
   end
 end

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -58,4 +58,18 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     get api_v1_code_school_path(id), as: :json
     assert_response :missing
   end
+
+  test ":get_moocs returns schools with is_Mooc set to true" do
+    @school.is_mooc = "true"
+    @school.save
+    get  api_v1_code_schools_get_moocs, as: :json
+    assert_equal JSON.parse(response.body)["name"], "CoderSchool"
+  end
+
+  test ":get_moocs does not return school when is_Mooc is false" do
+    @school.is_mooc = "false"
+    @school.save
+    get  api_v1_code_schools_get_moocs, as: :json
+    assert_response :missing
+  end
 end


### PR DESCRIPTION
# Description of changes
This PR adds a boolean is_mooc to the CodeSchools table and creates a /get_moocs endpoint for the front end. 
- is_mooc boolean is added to the CodeSchools table via a migration
- get_moocs action is added to the code_schools_controller to return all CodeSchools with is_mooc set to true
- Tests added to code_schools_controller_test.rb
- Route added to access endpoint
- Apiary documentation updated to reflect new endpoint

## QA
[ ] In the console, add several Code Schools. Give each school a different name and set is_mooc to true on some and false on others: 
```  
school1 = CodeSchool.create(name: "MySchools", url: "https://www.school.com", logo: "Mylogo", full_time:"false", hardware_included: "true", has_online: "true", online_only:"false", is_mooc:"false")
```
[ ] Running server, go to /api/v1/code_schools/get_moocs
[ ] You should see the Code Schools created ^ with is_mooc set to true, and not the ones with is_mooc set to false. 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #169 
