### PR TITLE
bug/235-update-sidekiq-container

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -41,3 +41,4 @@ EOF
 
 # Update the deployment
 KUBECONFIG=${KUBE_CONFIG} ./kubectl set image deployment/operationcode-backend app=operationcode/operationcode_backend:${TRAVIS_BUILD_NUMBER}
+KUBECONFIG=${KUBE_CONFIG} ./kubectl set image deployment/operationcode-backend operationcode-sidekiq=operationcode/operationcode_backend:${TRAVIS_BUILD_NUMBER}

--- a/bin/deploy
+++ b/bin/deploy
@@ -39,6 +39,10 @@ users:
     client-key-data: $KUBE_CLIENT_KEY
 EOF
 
-# Update the deployment
+# Updates the deployment
+#
+# Container names come from:
+# https://github.com/OperationCode/operationcode_infra/blob/master/kubernetes/operationcode_backend/deployment.yml
+#
 KUBECONFIG=${KUBE_CONFIG} ./kubectl set image deployment/operationcode-backend app=operationcode/operationcode_backend:${TRAVIS_BUILD_NUMBER}
 KUBECONFIG=${KUBE_CONFIG} ./kubectl set image deployment/operationcode-backend operationcode-sidekiq=operationcode/operationcode_backend:${TRAVIS_BUILD_NUMBER}


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Every merge to production updates the backend container image, but sidekiq, which also runs from the backend container image, doesn't get updated with new versions.

This PR triggers the updating of the sidekiq container image upon merge to production.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #235 
