### PR TITLE
 Authenticate Code Schools Controller and Update Tests

### DIFF
--- a/app/controllers/api/v1/code_schools_controller.rb
+++ b/app/controllers/api/v1/code_schools_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class CodeSchoolsController < ApplicationController
+      before_action :authenticate_user!, only: [:create, :update, :destroy]
+
       def index
         render json: CodeSchool.all
       end

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -20,7 +20,10 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
         name: "CoderSchool"
       }
     }
-    post api_v1_code_schools_url, params: params, headers: @headers, as: :json
+    post api_v1_code_schools_url,
+      params: params,
+      headers: @headers,
+      as: :json
 
     errors = JSON.parse(response.body)["errors"]
     assert errors.include? "Url can't be blank"

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -20,7 +20,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
         name: "CoderSchool"
       }
     }
-    post api_v1_code_schools_url, params: params, as: :json
+    post api_v1_code_schools_url, params: params, headers: @headers, as: :json
 
     errors = JSON.parse(response.body)["errors"]
     assert errors.include? "Url can't be blank"
@@ -29,9 +29,9 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
   test ":index endpoint returns a JSON list of all CodeSchools" do
     get api_v1_code_schools_path, as: :json
 
-    response = JSON.parse(response.body)[0]
-    location = response["locations"]
-    assert_equal response["name"], "CoderSchool"
+    body = JSON.parse(response.body)[0]
+    locations = body["locations"]
+    assert_equal body["name"], "CoderSchool"
     assert_not_nil locations
     assert_not_nil locations.first["address1"]
     assert_equal locations.first["address1"], "2405 Nugget Lane"
@@ -74,7 +74,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test ":update endpoint responds unauthorized for unauthenticated user" do
-    put api_v1_code_schools_path(@school),
+    put api_v1_code_school_path(@school),
       params: {name: "CoddderrrrSchool"},
       as: :json
     assert_response :unauthorized
@@ -91,7 +91,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test ":destroy endpoint responds unauthorized for unauthenticated user" do
-    delete api_v1_code_schools_path(@school), as: :json
+    delete api_v1_code_school_path(@school), as: :json
     assert_response :unauthorized
   end
 end

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -18,25 +18,33 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     }
     post api_v1_code_schools_url, params: params, as: :json
 
-    assert JSON.parse(response.body)["errors"].include? "Url can't be blank"
+    errors = JSON.parse(response.body)["errors"]
+    assert errors.include? "Url can't be blank"
   end
 
   test ":index endpoint returns a JSON list of all CodeSchools" do
     get api_v1_code_schools_path, as: :json
 
-    assert_equal JSON.parse(response.body)[0]["name"], "CoderSchool"
-    assert_not_nil JSON.parse(response.body)[0]["locations"]
-    assert_not_nil JSON.parse(response.body)[0]["locations"].first["address1"]
-    assert_equal JSON.parse(response.body)[0]["locations"].first["address1"], "2405 Nugget Lane"
+    response = JSON.parse(response.body)[0]
+    location = response["locations"]
+    assert_equal response["name"], "CoderSchool"
+    assert_not_nil locations
+    assert_not_nil locations.first["address1"]
+    assert_equal locations.first["address1"], "2405 Nugget Lane"
   end
 
   test ":create endpoint creates a CodeSchool successfully" do
-    post api_v1_code_schools_path(@school), params: {code_school: @school}, headers: @headers, as: :json
+    post api_v1_code_schools_path(@school),
+      params: {code_school: @school},
+      headers: @headers,
+      as: :json
     assert_response :ok
   end
 
   test ":create endpoint responds unauthorized for unauthenticated user" do
-    post api_v1_code_schools_path(@school), params: {code_school: @school}, as: :json
+    post api_v1_code_schools_path(@school),
+      params: {code_school: @school},
+      as: :json
     assert_response :unauthorized
   end
 
@@ -51,13 +59,20 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test ":update endpoint updates an existing CodeSchool" do
-    put api_v1_code_school_path(@school), params: {name: "CoddderrrrSchool"}, headers: @headers, as: :json
+    put api_v1_code_school_path(@school),
+      params: {name: "CoddderrrrSchool"},
+      headers: @headers,
+      as: :json
+
+    name = JSON.parse(response.body)["name"]
     assert_equal response.status, 200
-    assert_equal JSON.parse(response.body)["name"], "CoddderrrrSchool"
+    assert_equal name, "CoddderrrrSchool"
   end
 
   test ":update endpoint responds unauthorized for unauthenticated user" do
-    put api_v1_code_schools_path(@school), params: {name: "CoddderrrrSchool"}, as: :json
+    put api_v1_code_schools_path(@school),
+      params: {name: "CoddderrrrSchool"},
+      as: :json
     assert_response :unauthorized
   end
 

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -11,7 +11,6 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test ":validates CodeSchool's required fields" do
-    authenticate_user
     params = {
       code_school: {
         name: "CoderSchool"

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
   setup do
+    user = create(:user)
+    @headers = authorization_headers(user)
     @school = create(:code_school)
     @school.name = "CoderSchool"
     @school.save
@@ -9,6 +11,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test ":validates CodeSchool's required fields" do
+    authenticate_user
     params = {
       code_school: {
         name: "CoderSchool"
@@ -29,8 +32,13 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test ":create endpoint creates a CodeSchool successfully" do
-    post api_v1_code_schools_path(@school), params: {code_school: @school}, as: :json
+    post api_v1_code_schools_path(@school), params: {code_school: @school}, headers: @headers, as: :json
     assert_response :ok
+  end
+
+  test ":create endpoint responds unauthorized for unauthenticated user" do
+    post api_v1_code_schools_path(@school), params: {code_school: @school}, as: :json
+    assert_response :unauthorized
   end
 
   test ":show will not work for a invalid record" do
@@ -44,18 +52,28 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test ":update endpoint updates an existing CodeSchool" do
-    put api_v1_code_school_path(@school), params: {name: "CoddderrrrSchool"}, as: :json
+    put api_v1_code_school_path(@school), params: {name: "CoddderrrrSchool"}, headers: @headers, as: :json
     assert_equal response.status, 200
     assert_equal JSON.parse(response.body)["name"], "CoddderrrrSchool"
+  end
+
+  test ":update endpoint responds unauthorized for unauthenticated user" do
+    put api_v1_code_schools_path(@school), params: {name: "CoddderrrrSchool"}, as: :json
+    assert_response :unauthorized
   end
 
   test ":destroy endpoint destroys an existing CodeSchool" do
     id = @school.id
 
-    delete api_v1_code_school_path(@school)
+    delete api_v1_code_school_path(@school), headers: @headers
     assert_equal response.status, 200
 
     get api_v1_code_school_path(id), as: :json
     assert_response :missing
+  end
+
+  test ":destroy endpoint responds unauthorized for unauthenticated user" do
+    delete api_v1_code_schools_path(@school), as: :json
+    assert_response :unauthorized
   end
 end

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -42,7 +42,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
 
   test ":create endpoint creates a CodeSchool successfully" do
     post api_v1_code_schools_path(@school),
-      params: {code_school: @school},
+      params: { code_school: @school },
       headers: @headers,
       as: :json
     assert_response :ok
@@ -50,7 +50,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
 
   test ":create endpoint responds unauthorized for unauthenticated user" do
     post api_v1_code_schools_path(@school),
-      params: {code_school: @school},
+      params: { code_school: @school },
       as: :json
     assert_response :unauthorized
   end
@@ -67,7 +67,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
 
   test ":update endpoint updates an existing CodeSchool" do
     put api_v1_code_school_path(@school),
-      params: {name: "CoddderrrrSchool"},
+      params: { name: "CoddderrrrSchool" },
       headers: @headers,
       as: :json
 
@@ -78,7 +78,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
 
   test ":update endpoint responds unauthorized for unauthenticated user" do
     put api_v1_code_school_path(@school),
-      params: {name: "CoddderrrrSchool"},
+      params: { name: "CoddderrrrSchool" },
       as: :json
     assert_response :unauthorized
   end

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -7,7 +7,11 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     @school = create(:code_school)
     @school.name = "CoderSchool"
     @school.save
-    @location = create(:location, code_school: @school, address1: "2405 Nugget Lane")
+    @location = create(
+      :location,
+      code_school: @school,
+      address1: "2405 Nugget Lane"
+    )
   end
 
   test ":validates CodeSchool's required fields" do


### PR DESCRIPTION
# Description of changes
Adds the authenticate_user! before action for create, update and destroy on codeschools controller.

Updates tests for each of these actions.

# Issue Resolved
Fixes #239
