### PR TITLE
Add Skylight instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'redis', '~> 3.0'
 gem 'sendgrid-ruby'
 gem 'sentry-raven'
 gem 'sidekiq'
+gem 'skylight'
 gem 'pry-rails'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,8 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
+    skylight (1.5.0)
+      activesupport (>= 3.0.0)
     spring (2.0.1)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)


### PR DESCRIPTION
I discussed with @nellshamrell about adding [Skylight](https://www.skylight.io) instrumentation to the Operation Code website under the new [Skylight for Open Source](https://www.skylight.io/oss) program.

If you’re not already familiar with Skylight, it is a smart profiler for Rails apps. Skylight makes it easy to pinpoint performance issues in Rails applications.

We work on a lot of open source projects ourselves, and in our experience it can be pretty hard to get contributors to work on application performance issues. Few contributors consider working on performance problems, and the ones that might be interested may not even know where to start. By making performance information more accessible, we hope to inspire potential contributors to tackle slow parts of your app, and have a good way to see if their contributions helped.

Once this patch is merged and deloyed*, you will be able to view the performance data we collected at the [public Skylight dashboard](https://oss.skylight.io/app/applications/0iQU6bEW8ha1/recent/5m/endpoints). The dashboard will be accessible to anyone (no Skylight account required) to make it easy for contributors. Once that is up and running, we can probably link to it from the README.

(*Actually, I lied a little. We still need to set the `SKYLIGHT_AUTHENTICATION` environment variable to the appropiate API key on production, but I will work with @nellshamrell on that off-thread.)
