### PR TITLE
Feature/251 code schools index sort by name

### DIFF
--- a/app/controllers/api/v1/code_schools_controller.rb
+++ b/app/controllers/api/v1/code_schools_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :authenticate_user!, only: [:create, :update, :destroy]
 
       def index
-        render json: CodeSchool.all
+        render json: CodeSchool.order(:name)
       end
 
       def create

--- a/app/serializers/code_school_serializer.rb
+++ b/app/serializers/code_school_serializer.rb
@@ -1,4 +1,8 @@
 class CodeSchoolSerializer < ActiveModel::Serializer
   attributes :name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only
   has_many :locations
+
+  def locations
+    object.locations.order(:state).order(:city)
+  end
 end


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
For the JSON response on the `api/v1/code_schools_controller#index` endpoint:

- [ ] Sets the default sort to `code_school#name`
- [ ] Sets the secondary sort to `location#state`
- [ ] Sets the tertiary sort to `location#city`

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #251 
