### PR TITLE
remove incorrect note section, add that we are a VA approved code school

### DIFF
--- a/config/code_schools.yml
+++ b/config/code_schools.yml
@@ -747,10 +747,9 @@
   hardware_included: false
   has_online: true
   online_only: false
-  notes: Completely free for accepted applicants. This is a non-profit code school.
   email: info@codeplatoon.org
   locations:
-    - va_accepted: false
+    - va_accepted: true
       address1: 73 W Monroe Street
       address2: Suite 303
       city: Chicago


### PR DESCRIPTION
# Description of changes
This solves https://github.com/OperationCode/operationcode_backend/issues/255. Code Platoon was approved for the GI Bill and we want to reflect that in our entry with Operation Code.