### PR TITLE
Adds the cron Whenever gem for daily runs of GitHub statistics rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'sentry-raven'
 gem 'sidekiq'
 gem 'skylight'
 gem 'pry-rails'
+gem 'whenever', '~> 0.10.0'
 
 group :development, :test do
   gem 'awesome_print', '~> 1.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
     byebug (9.0.6)
     case_transform (0.2)
       activesupport
+    chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -209,6 +210,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whenever (0.10.0)
+      chronic (>= 0.6.3)
 
 PLATFORMS
   ruby
@@ -241,10 +244,12 @@ DEPENDENCIES
   sendgrid-ruby
   sentry-raven
   sidekiq
+  skylight
   spring
   spring-watcher-listen (~> 2.0.0)
   vcr (~> 3.0, >= 3.0.3)
   webmock (~> 3.0, >= 3.0.1)
+  whenever (~> 0.10.0)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,10 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+#
+# Learn more: http://github.com/javan/whenever
+
+every 1.day, at: '3:00' do
+  rake "git_hub:collect_statistics"
+end


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
We need to be able to have recurring cron jobs ran, on our behalf.  For example, to hit GitHub's API, or the Meetup API, on a daily basis, to pull in current statistics or Meetup events.

The [whenever gem](https://github.com/javan/whenever) is a perfect tool to solve this.  

This implements the backend.  

In order for this to go live in prod, infrastructure will need to be added and addressed.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #163 
