### PR TITLE
Add Skylight performance monitoring badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OperationCode Backend
 
+[![View performance data on Skylight](https://badges.skylight.io/status/0iQU6bEW8ha1.svg)](https://oss.skylight.io/app/applications/0iQU6bEW8ha1)
+
 ## Contributing to Operation Code
 
 So, you want to learn how to program? Contributing to Operation Code is a great place to get started. This document will help you march from zero to deploying code in no time!


### PR DESCRIPTION
Hi there! 👋 

I work at Skylight, and had chatted over email with @nellshamrell about adding a Skylight performance badge to the Operation Code README as part of the Skylight for Open Source program. This PR follows up on the [recent addition](https://github.com/OperationCode/operationcode_backend/pull/249) of Skylight instrumentation added by @chancancode.

Please do let me know if there is a better place to put this badge; I followed what I have seen other open source repositories do, but I can move it if you'd prefer!