### PR TITLE
bug/Eliminates validation conflict with database default

### DIFF
--- a/app/models/code_school.rb
+++ b/app/models/code_school.rb
@@ -1,5 +1,5 @@
 class CodeSchool < ApplicationRecord
-  validates :name, :url, :logo, :mooc, presence: true
+  validates :name, :url, :logo, presence: true
   validates_inclusion_of :full_time, :hardware_included, :has_online, :online_only, :in => [true, false]
   has_many :locations, dependent: :destroy
 end

--- a/test/factories/code_schools.rb
+++ b/test/factories/code_schools.rb
@@ -8,6 +8,6 @@ FactoryGirl.define do
     has_online Faker::Boolean.boolean
     online_only Faker::Boolean.boolean
     notes Faker::Lorem.paragraph
-    mooc Faker::Boolean.boolean
+    mooc false
   end
 end


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Since the addition of the `mooc` attr to the `CodeSchool` table, there is a validation issue that prevents a new one from being created.  Each time there is a rollback, with the error:

```
{:mooc=>["can't be blank"]}
```

This was caused by conflict between the default and null requirements at the database level, in conjunction with the validation of presence at the Rails layer level.

This PR resolves that by removing the validation for presence, as the database backstops the validation for presence.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #262 
