### PR TITLE
Created update:school_logos and helper schools:populate rake cmds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,21 +47,10 @@ db_rollback:
 db_seed:
 	docker-compose run ${RAILS_CONTAINER} rake db:seed
 
-.PHONY: schools_populate
-schools_populate:
-	docker-compose run ${RAILS_CONTAINER} rake schools:populate
-
-.PHONY: update_school_logos
-update_schools_logos:
-	docker-compose run ${RAILS_CONTAINER} rake update:school_logos
-
 .PHONY: test
 test: bg
 	docker-compose run operationcode-psql bash -c "while ! psql --host=operationcode-psql --username=postgres -c 'SELECT 1'; do sleep 5; done;"
 	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && rake db:test:prepare && rake test'
-
-test_logos:
-	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && rake db:test:prepare && rake test TEST=test/lib/update_school_logos_test.rb'
 
 .PHONY: bundle
 bundle:

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,21 @@ db_rollback:
 db_seed:
 	docker-compose run ${RAILS_CONTAINER} rake db:seed
 
+.PHONY: schools_populate
+schools_populate:
+	docker-compose run ${RAILS_CONTAINER} rake schools:populate
+
+.PHONY: update_school_logos
+update_schools_logos:
+	docker-compose run ${RAILS_CONTAINER} rake update:school_logos
+
 .PHONY: test
 test: bg
 	docker-compose run operationcode-psql bash -c "while ! psql --host=operationcode-psql --username=postgres -c 'SELECT 1'; do sleep 5; done;"
 	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && rake db:test:prepare && rake test'
+
+test_logos:
+	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && rake db:test:prepare && rake test TEST=test/lib/update_school_logos_test.rb'
 
 .PHONY: bundle
 bundle:

--- a/lib/tasks/update_schools_logo.rake
+++ b/lib/tasks/update_schools_logo.rake
@@ -1,0 +1,15 @@
+namespace :update do
+  desc "Update code schools logo from github assets to AWS S3"
+  task school_logos: :environment do
+    schools = CodeSchool.all
+    schools.each do |school|
+      logo = school.logo
+      if logo.include? "https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images"
+        new_logo = logo.sub("https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images", "https://s3.amazonaws.com/operationcode-assets")
+        
+        school.logo = new_logo
+        school.save
+      end
+    end
+  end
+end

--- a/test/lib/update_school_logos_test.rb
+++ b/test/lib/update_school_logos_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class UpdateSchoolLogosTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks
+    if !CodeSchool.exists?
+      Rake::Task['schools:populate'].invoke
+    end
+  end
+
+  test 'it asserts schools\' logos contain aws urls' do
+    Rake::Task['update:school_logos'].invoke
+    schools = CodeSchool.all
+    assert_kind_of CodeSchool::ActiveRecord_Relation, schools
+    schools.each do |school|
+      logo = school.logo
+      assert_match "https://s3.amazonaws.com/operationcode-assets", logo
+    end
+  end
+end


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Creates rake tasks to update `CodeSchool` records' `logo` attribute to use aws hosted images instead of GitHub's assets.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #284 
