### PR TITLE
293 tiered admin access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ end
 gem 'activeadmin', '~> 1.1'
 gem 'active_model_serializers'
 gem 'acts-as-taggable-on', '~> 5.0'
+gem 'cancancan', '~> 2.0'
 gem 'devise'
 gem 'forest_liana'
 gem 'geocoder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     bcrypt (3.1.11)
     builder (3.2.3)
     byebug (9.0.6)
+    cancancan (2.1.3)
     case_transform (0.2)
       activesupport
     coderay (1.1.2)
@@ -299,6 +300,7 @@ DEPENDENCIES
   acts-as-taggable-on (~> 5.0)
   awesome_print (~> 1.8)
   byebug
+  cancancan (~> 2.0)
   devise
   factory_girl_rails
   faker

--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -5,9 +5,11 @@ ActiveAdmin.register AdminUser do
     selectable_column
     id_column
     column :email
+
     column "Role" do |admin_user|
       admin_user.role.title
     end
+
     column :current_sign_in_at
     column :sign_in_count
     column :created_at
@@ -22,10 +24,15 @@ ActiveAdmin.register AdminUser do
   form do |f|
     f.inputs do
       f.input :email
-      f.input :role_id, label: 'Role', as: :select, collection: Role.all.order(:title).map { |role| [role.title, role.id]}, include_blank: false
+
+      if current_admin_user.role.super_admin?
+        f.input :role_id, label: 'Role', as: :select, collection: Role.all.order(:title).map { |role| [role.title, role.id]}, include_blank: false
+      end
+
       f.input :password
       f.input :password_confirmation
     end
+
     f.actions
   end
 end

--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -1,10 +1,13 @@
 ActiveAdmin.register AdminUser do
-  permit_params :email, :password, :password_confirmation
+  permit_params :email, :password, :password_confirmation, :role_id
 
   index do
     selectable_column
     id_column
     column :email
+    column "Role" do |admin_user|
+      admin_user.role.title
+    end
     column :current_sign_in_at
     column :sign_in_count
     column :created_at
@@ -19,10 +22,10 @@ ActiveAdmin.register AdminUser do
   form do |f|
     f.inputs do
       f.input :email
+      f.input :role_id, label: 'Role', as: :select, collection: Role.all.order(:title).map { |role| [role.title, role.id]}, include_blank: false
       f.input :password
       f.input :password_confirmation
     end
     f.actions
   end
-
 end

--- a/app/controllers/api/v1/social_users_controller.rb
+++ b/app/controllers/api/v1/social_users_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class SocialUsersController < ApplicationController
+    class SocialUsersController < ApiController
 
       # For social media logins, renders the appropriate `redirect_to` path depending on whether the user is registered.
       #

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :null_session
 
   def access_denied(exception)
-    redirect_to new_admin_user_session_path, alert: exception.message
+    redirect_to admin_root_path, alert: exception.message
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,8 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :null_session
+
+  def access_denied(exception)
+    redirect_to new_admin_user_session_path, alert: exception.message
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,39 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    # user ||= User.new # guest user (not logged in)
+    if user.persisted? && user.class == AdminUser
+      if user.role&.super_admin?
+        can :manage, :all
+      elsif user.role&.admin?
+        can :read, :all
+        can :manage, User
+        can :manage, AdminUser, id: user.id
+      elsif user.role&.board?
+        can :read, :all
+        can :manage, AdminUser, id: user.id
+      end
+    end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,38 +2,22 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    # Define abilities for the passed in user here. For example:
+    # Follows CanCanCan best practices for granting permissions.
     #
-    # user ||= User.new # guest user (not logged in)
+    # @see https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities%3A-Best-Practices#give-permissions-dont-take-them-away
+    #
     if user.persisted? && user.class == AdminUser
-      if user.role&.super_admin?
-        can :manage, :all
-      elsif user.role&.admin?
-        can :read, :all
-        can :manage, User
-        can :manage, AdminUser, id: user.id
-      elsif user.role&.board?
-        can :read, :all
-        can :manage, AdminUser, id: user.id
-      end
+      return unless user.role&.board_accessible?
+      can :read, ActiveAdmin::Page, name: "Dashboard", namespace_name: "admin"
+      can :read, User
+      can [:read, :update], AdminUser, id: user.id
+
+      return unless user.role&.admin_accessible?
+      can :read, :all
+      can :manage, User
+
+      return unless user.role&.super_admin?
+      can :manage, :all
     end
-    #
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, :published => true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
   end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,6 +1,22 @@
 class AdminUser < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, 
+  devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  before_save :set_role
+
+  def role
+    return if role_id.blank?
+
+    Role.find_by id: role_id
+  end
+
+  private
+
+  def set_role
+    if role_id.blank?
+      self.role_id = Role.find_by(title: Role::BOARD)&.id
+    end
+  end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -8,12 +8,6 @@ class AdminUser < ApplicationRecord
 
   before_save :set_role
 
-  def role
-    return if role_id.blank?
-
-    Role.find_by id: role_id
-  end
-
   private
 
   def set_role

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -4,6 +4,8 @@ class AdminUser < ApplicationRecord
   devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  belongs_to :role
+
   before_save :set_role
 
   def role

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,5 +1,22 @@
 class Role < ApplicationRecord
+  SUPER_ADMIN = 'super_admin'.freeze
+  ADMIN = 'admin'.freeze
+  BOARD = 'board_member'.freeze
+
   has_many :users
+  has_many :admin_users
 
   validates :title, presence: true, uniqueness: true
+
+  def super_admin?
+    title == SUPER_ADMIN
+  end
+
+  def admin?
+    title == ADMIN
+  end
+
+  def board?
+    title == BOARD
+  end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,12 +1,20 @@
 class Role < ApplicationRecord
-  SUPER_ADMIN = 'super_admin'.freeze
-  ADMIN = 'admin'.freeze
-  BOARD = 'board_member'.freeze
+  SUPER_ADMIN = 'super_admin'
+  ADMIN = 'admin'
+  BOARD = 'board_member'
 
   has_many :users
   has_many :admin_users
 
   validates :title, presence: true, uniqueness: true
+
+  def board_accessible?
+    [BOARD, ADMIN, SUPER_ADMIN].include? title
+  end
+
+  def admin_accessible?
+    [ADMIN, SUPER_ADMIN].include? title
+  end
 
   def super_admin?
     title == SUPER_ADMIN

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -62,7 +62,7 @@ ActiveAdmin.setup do |config|
   # method in a before filter of all controller actions to
   # ensure that there is a user with proper rights. You can use
   # CanCanAdapter or make your own. Please refer to documentation.
-  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+  config.authorization_adapter = ActiveAdmin::CanCanAdapter
 
   # In case you prefer Pundit over other solutions you can here pass
   # the name of default policy class. This policy will be used in every
@@ -77,7 +77,7 @@ ActiveAdmin.setup do |config|
   # because, by default, user gets redirected to Dashboard. If user
   # doesn't have access to Dashboard, he'll end up in a redirect loop.
   # Method provided here should be defined in application_controller.rb.
-  # config.on_unauthorized_access = :access_denied
+  config.on_unauthorized_access = :access_denied
 
   # == Current User
   #

--- a/db/migrate/20180408172532_add_role_id_to_admin_user.rb
+++ b/db/migrate/20180408172532_add_role_id_to_admin_user.rb
@@ -1,0 +1,5 @@
+class AddRoleIdToAdminUser < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :admin_users, :role, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180401034441) do
+ActiveRecord::Schema.define(version: 20180408172532) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,8 +42,10 @@ ActiveRecord::Schema.define(version: 20180401034441) do
     t.inet     "last_sign_in_ip"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.integer  "role_id"
     t.index ["email"], name: "index_admin_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["role_id"], name: "index_admin_users_on_role_id", using: :btree
   end
 
   create_table "code_schools", force: :cascade do |t|


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Currently in order to give a user access to the admin dashboard, we have to grant them "super admin" privileges.

We want to be able to give people access to view and filter, but not the ability to create or update any records.

This PR establishes the foundation for this tiered access to the admin dashboard's offerings.  Namely it:

- [x] Creates three roles: super admin, admin, and board member
- [x] gives super admins unfettered access, including the ability to create new admin dashboard users
- [x] gives admins access to read everything, as well as CRUD access to the `User` table
- [x] gives board members read access to the `User` table


# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #293 
