### PR TITLE
294 code schools in admin dashboard

### DIFF
--- a/app/admin/code_school.rb
+++ b/app/admin/code_school.rb
@@ -1,0 +1,42 @@
+ActiveAdmin.register CodeSchool do
+  permit_params :name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only, :created_at, :updated_at, :notes, :mooc
+
+  index do
+    selectable_column
+    id_column
+
+    column :name
+    column :url
+    column :logo
+    column :full_time
+    column :hardware_included
+    column :has_online
+    column :online_only
+    column :created_at
+    column :updated_at
+    column :notes
+    column :mooc
+    column :created_at
+    column :updated_at
+
+    actions
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :url
+      f.input :logo
+      f.input :full_time
+      f.input :hardware_included
+      f.input :has_online
+      f.input :online_only
+      f.input :created_at
+      f.input :updated_at
+      f.input :notes
+      f.input :mooc
+    end
+
+    f.actions
+  end
+end

--- a/app/admin/location.rb
+++ b/app/admin/location.rb
@@ -1,0 +1,37 @@
+ActiveAdmin.register Location do
+  permit_params :va_accepted, :address1, :address2, :city, :state, :zip, :code_school_id
+
+  index do
+    selectable_column
+    id_column
+
+    column "Code School" do |location|
+      location.code_school.name
+    end
+
+    column :va_accepted
+    column :address1
+    column :address2
+    column :city
+    column :state
+    column :zip
+    column :created_at
+    column :updated_at
+
+    actions
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :code_school_id, label: 'Code School', as: :select, collection: CodeSchool.all.order(:name).map { |school| [school.name, school.id]}, include_blank: false
+      f.input :va_accepted
+      f.input :address1
+      f.input :address2
+      f.input :city
+      f.input :state
+      f.input :zip
+    end
+
+    f.actions
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,19 +1,23 @@
 class Ability
   include CanCan::Ability
 
+  # Follows CanCanCan best practices for granting permissions.
+  #
+  # @see https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities%3A-Best-Practices#give-permissions-dont-take-them-away
+  #
   def initialize(user)
-    # Follows CanCanCan best practices for granting permissions.
-    #
-    # @see https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities%3A-Best-Practices#give-permissions-dont-take-them-away
-    #
     if user.persisted? && user.class == AdminUser
       return unless user.role&.board_accessible?
-      can :read, ActiveAdmin::Page, name: "Dashboard", namespace_name: "admin"
+      can :read, ActiveAdmin::Page, name: 'Dashboard', namespace_name: 'admin'
+      can :read, CodeSchool
+      can :read, Location
       can :read, User
       can [:read, :update], AdminUser, id: user.id
 
       return unless user.role&.admin_accessible?
       can :read, :all
+      can :manage, CodeSchool
+      can :manage, Location
       can :manage, User
 
       return unless user.role&.super_admin?


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Gives admins the ability to conduct CRUD actions on the `CodeSchool` and `Location` models.  

# Definition of done

- [x] Adds a Resource for `CodeSchool` to ActiveAdmin
- [x] Adds a Resource for `Location` to ActiveAdmin
- [x] Updates `ability.rb` to set admin dashboard permissions, per role

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #294 
