### PR TITLE
Removes db auto-filled fields from admin forms

### DIFF
--- a/app/admin/code_school.rb
+++ b/app/admin/code_school.rb
@@ -31,8 +31,6 @@ ActiveAdmin.register CodeSchool do
       f.input :hardware_included
       f.input :has_online
       f.input :online_only
-      f.input :created_at
-      f.input :updated_at
       f.input :notes
       f.input :mooc
     end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -89,4 +89,37 @@ ActiveAdmin.register User do
   remove_filter :taggings
   remove_filter :tag_taggings
   filter :with_tags, label: 'Tagged With', as: :select, collection: ->{ User.all_tag_names }
+
+  form do |f|
+    f.inputs do
+      f.input :email
+      f.input :zip
+      f.input :mentor
+      f.input :slack_name
+      f.input :first_name
+      f.input :last_name
+      f.input :timezone
+      f.input :bio
+      f.input :verified
+      f.input :state
+      f.input :city
+      f.input :username
+      f.input :volunteer
+      f.input :branch_of_service
+      f.input :years_of_service
+      f.input :pay_grade
+      f.input :military_occupational_specialty
+      f.input :github
+      f.input :twitter
+      f.input :linkedin
+      f.input :employment_status
+      f.input :education
+      f.input :company_role
+      f.input :company_name
+      f.input :education_level
+      f.input :interests
+    end
+
+    f.actions
+  end
 end


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
There are certain fields that the database automatically populates on our behalf, and should not be manually adjusted.  This PR removes those fields from the admin dashboard's forms.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #304 
