### PR TITLE
309 email for team members

### DIFF
--- a/app/admin/team_member.rb
+++ b/app/admin/team_member.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register TeamMember do
-  permit_params :name, :role, :description, :group, :image_src
+  permit_params :name, :role, :description, :group, :image_src, :email
 
   index do
     selectable_column
@@ -7,6 +7,7 @@ ActiveAdmin.register TeamMember do
 
     column :name
     column :role
+    column :email
     column :created_at
     column :updated_at
     column :description
@@ -20,6 +21,7 @@ ActiveAdmin.register TeamMember do
     f.inputs do
       f.input :name
       f.input :role
+      f.input :email
       f.input :description
       f.input :group
       f.input :image_src

--- a/app/controllers/api/v1/team_members_controller.rb
+++ b/app/controllers/api/v1/team_members_controller.rb
@@ -36,7 +36,7 @@ module Api
     private
 
       def team_member_params
-        params.permit(:name, :role, :group, :description, :image_src)
+        params.permit(:name, :role, :group, :description, :image_src, :email)
       end
     end
   end

--- a/config/board_members.yml
+++ b/config/board_members.yml
@@ -27,6 +27,7 @@
   image_src: https://s3.amazonaws.com/operationcode-assets/headshots/david_molina.jpg
   name: David Molina
   role: Executive Director
+  email: david@operationcode.org
 
 - description: Liza Rodewald is an entrepreneur, full stack .NET web developer, and co-founder and CTO of MadSkills, a startup helping military spouses find employment. Her first business, LMS Software, has contracted multi-million dollar projects with the government and private sector. Liza, a military spouse, has a passion to see others succeed, and actively advocates for and mentors women in technology,
   image_src: https://s3.amazonaws.com/operationcode-assets/headshots/liza_rodewald.jpg

--- a/config/team_members.yml
+++ b/config/team_members.yml
@@ -7,21 +7,26 @@
 
 - name: Amy Tan
   role: CFO
+  email: amy@operationcode.org
 
 - name: Ashley Templet
   role: CCO
+  email: ashley@operationcode.org
 
 - name: David Reis
   role: COO acting
 
 - name: Jameel Matin
   role: Public Policy Director
+  email: jameel@operationcode.org
 
 - name: Jennifer Weidman
   role: CCMO CDO
+  email: jennifer@operationcode.org
 
 - name: Kelly MacLeod
   role: People Operations
+  email: kelly@operationcode.org
 
 - name: Matthew Walter
   role: Infrastructure Lead
@@ -37,6 +42,7 @@
 
 - name: Nell Shamrell
   role: CTO
+  email: nell@operationcode.org
 
 - name: Stephano D'Aniello
   role: General Counsel

--- a/db/migrate/20180416024105_add_email_to_team_member.rb
+++ b/db/migrate/20180416024105_add_email_to_team_member.rb
@@ -1,0 +1,5 @@
+class AddEmailToTeamMember < ActiveRecord::Migration[5.0]
+  def change
+    add_column :team_members, :email, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180408172532) do
+ActiveRecord::Schema.define(version: 20180416024105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -216,11 +216,12 @@ ActiveRecord::Schema.define(version: 20180408172532) do
   create_table "team_members", force: :cascade do |t|
     t.string   "name"
     t.string   "role"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
     t.text     "description"
     t.string   "group"
     t.string   "image_src"
+    t.string   "email",       limit: 255
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
In order to finish up front-end issue https://github.com/OperationCode/operationcode_frontend/issues/943, the API call to https://api.operationcode.org/api/v1/team_members needs to return an `email` field for executive staff team members (non-board). This `email` field is already in the static client-side data ([executiveStaff.js](https://github.com/OperationCode/operationcode_frontend/blob/master/src/scenes/home/team/executiveStaff.js)) that will be replaced by the fetched API data.

- [x] Adds a string `email` field to the `team_members` table in the [DB schema](https://github.com/OperationCode/operationcode_backend/blob/master/db/schema.rb)
- [x] Updates the below members in the prod DB with their OC email addresses (or just ping me when the back-end is ready, and I can just add them via the Admin Dashboard). Anyone not in that list can simply have a `null` value for `email`
- [x] Ensures API call to `https://api.operationcode.org/api/v1/team_members` returns correct updated data
- [x] Adds new column to the admin dashboard
 --------------------
- David Molina: `david@operationcode.org`
- Jennifer Wiedeman: `jennifer@operationcode.org`
- Amy Tan: `amy@operationcode.org`
- Nell Shamrell: `nell@operationcode.org`
- Ashley Templet: `ashley@operationcode.org`
- Kelly MacLeod: `kelly@operationcode.org`
- Jameel Matin: `jameel@operationcode.org`

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #309 