### PR TITLE
Add is_partner to the CodeSchool table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,7 @@ publish: build
 
 upgrade: publish
 	bin/deploy
+
+.PHONY: is_partner
+is_partner:
+	docker-compose run ${RAILS_CONTAINER} rake users:is_partner

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,3 @@ publish: build
 
 upgrade: publish
 	bin/deploy
-
-.PHONY: is_partner
-is_partner:
-	docker-compose run ${RAILS_CONTAINER} rake users:is_partner

--- a/apiary.apib
+++ b/apiary.apib
@@ -70,12 +70,12 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                       "name": "CoderSchool",
                       "url": "http://www.CoderSchool.vn",
                       "logo": "https://d388w23p6r1vqc.cloudfront.net/img/startups/11852/logo-1457327647.png",
-                      "full_time": "false",
-                      "hardware_included": "false",
-                      "has_online": "true",
-                      "online_only": "false",
+                      "full_time": false,
+                      "hardware_included": false,
+                      "has_online": true,
+                      "online_only": false,
                       "is_partner": false,
-                      "mooc": "false"
+                      "mooc": false
                       }
                   }
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -20,6 +20,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                 "hardware_included": false,
                 "has_online": false,
                 "online_only": false,
+                "is_partner": false,
                 "mooc": false
                 "locations":  [
                       {
@@ -40,7 +41,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
             },
         ]
 
-## CodeSchool | Create [/api/v1/code_schools{?name,url,logo,full_time,hardware_included,has_online,online_only,notes,mooc}]
+## CodeSchool | Create [/api/v1/code_schools{?name,url,logo,full_time,hardware_included,has_online,online_only,notes,is_partner,mooc}]
 + Parameters
 
     + name (string, required) - The CodeSchool's name
@@ -51,6 +52,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
     + has_online (boolean, required) - Does the CodeSchool have an online component
     + online_only (boolean, required) - Is the CodeSchool online only?
     + notes (text, optional) - Any additional information about the CodeSchool
+    + is_partner(boolean, required) - Is the CodeSchool a partner
     + mooc (boolean, optional) - Does the CodeSchool offer Massive Open Online Courses?
 
 ### Create a CodeSchool Member [POST]
@@ -71,7 +73,8 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                       "full_time": "false",
                       "hardware_included": "false",
                       "has_online": "true",
-                      "online_only": "false"
+                      "online_only": "false",
+                      "is_partner": false,
                       "mooc": "false"
                       }
                   }
@@ -111,6 +114,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
             "created_at": "2017-09-26T06:54:58.607Z",
             "updated_at": "2017-09-26T06:54:58.607Z",
             "notes": null,
+            "is_partner": false,
             "mooc": false
         }
 
@@ -150,7 +154,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                   errors: "Some error message"
               }
 
-## CodeSchool | Update [/api/v1/code_schools/{code_school_id}{?name,url,logo,full_time,hardware_included,has_online,online_only,notes,mooc}]
+## CodeSchool | Update [/api/v1/code_schools/{code_school_id}{?name,url,logo,full_time,hardware_included,has_online,online_only,notes,is_partner,mooc}]
 
 + Parameters
 

--- a/app/controllers/api/v1/code_schools_controller.rb
+++ b/app/controllers/api/v1/code_schools_controller.rb
@@ -47,7 +47,7 @@ module Api
       private
 
       def code_school_params
-        params.require(:code_school).permit(:name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only, :mooc)
+        params.require(:code_school).permit(:name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only, :mooc, :is_partner)
       end
     end
   end

--- a/app/serializers/code_school_serializer.rb
+++ b/app/serializers/code_school_serializer.rb
@@ -1,5 +1,5 @@
 class CodeSchoolSerializer < ActiveModel::Serializer
-  attributes :name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only, :mooc
+  attributes :name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only, :mooc, :is_partner
   has_many :locations
 
   def locations

--- a/db/migrate/20180420192231_add_is_partner_to_code_schools.rb
+++ b/db/migrate/20180420192231_add_is_partner_to_code_schools.rb
@@ -1,0 +1,5 @@
+class AddIsPartnerToCodeSchools < ActiveRecord::Migration[5.0]
+  def change
+    add_column :code_schools, :is_partner, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
-ActiveRecord::Schema.define(version: 20180416024105) do
-=======
 ActiveRecord::Schema.define(version: 20180420192231) do
->>>>>>> migration completed
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 20180416024105) do
+=======
+ActiveRecord::Schema.define(version: 20180420192231) do
+>>>>>>> migration completed
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +64,7 @@ ActiveRecord::Schema.define(version: 20180416024105) do
     t.datetime "updated_at",                        null: false
     t.text     "notes"
     t.boolean  "mooc",              default: false, null: false
+    t.boolean  "is_partner",        default: false, null: false
   end
 
   create_table "events", force: :cascade do |t|

--- a/lib/tasks/update_is_partner_for_code_schools.rake
+++ b/lib/tasks/update_is_partner_for_code_schools.rake
@@ -1,21 +1,19 @@
 namespace :is_partner do
   desc "Updates column is_partner for code schools"
   task code_schools: :environment do
-
     is_partner_schools = [
-                          {name: "Bloc"},
-                          {name: "Coder Camps"},
-                          {name: "Code Platoon"},
-                          {name: "The Flatiron School"},
-                          {name: "Fullstack Academy"},
-                          {name: "Launch School"},
-                          {name: "Sabio"},
-                          {name: "Startup Institute"},
-                          {name: "Thinkful"},
-                         ]
-
-    is_parnter_school_name_array = is_partner_schools.map { |u| u[:name] }
-    schools = CodeSchool.where(name: is_partner_school_name_array)
+                           "Bloc",
+                           "Coder Camps",
+                           "Code Platoon",
+                           "The Flatiron School",
+                           "Fullstack Academy",
+                           "Launch School",
+                           "Sabio",
+                           "Startup Institute",
+                           "Thinkful"
+                          ]
+                          
+    schools = CodeSchool.where(name: is_partner_schools)
 
     schools.each do |school|
       next if school.is_partner?

--- a/lib/tasks/update_is_partner_for_code_schools.rake
+++ b/lib/tasks/update_is_partner_for_code_schools.rake
@@ -1,0 +1,8 @@
+namespace :is_partner do
+  desc "Updates column is_partner for code schools"
+  task code_schools: :environment do
+    schools = CodeSchools.all
+    schools.is_partner = true
+    schools.save
+  end
+end

--- a/lib/tasks/update_is_partner_for_code_schools.rake
+++ b/lib/tasks/update_is_partner_for_code_schools.rake
@@ -1,8 +1,26 @@
 namespace :is_partner do
   desc "Updates column is_partner for code schools"
   task code_schools: :environment do
-    schools = CodeSchools.all
-    schools.is_partner = true
-    schools.save
+
+    is_partner_schools = [
+                          {name: "Bloc"},
+                          {name: "Coder Camps"},
+                          {name: "Code Platoon"},
+                          {name: "The Flatiron School"},
+                          {name: "Fullstack Academy"},
+                          {name: "Launch School"},
+                          {name: "Sabio"},
+                          {name: "Startup Institute"},
+                          {name: "Thinkful"},
+                         ]
+
+    is_parnter_school_name_array = is_partner_schools.map { |u| u[:name] }
+    schools = CodeSchool.where(name: is_partner_school_name_array)
+
+    schools.each do |school|
+      next if school.is_partner?
+      school.is_partner = true
+      school.save
+    end
   end
 end

--- a/test/factories/code_schools.rb
+++ b/test/factories/code_schools.rb
@@ -9,5 +9,6 @@ FactoryGirl.define do
     online_only Faker::Boolean.boolean
     notes Faker::Lorem.paragraph
     mooc false
+    is_partner false
   end
 end

--- a/test/models/code_schools_test.rb
+++ b/test/models/code_schools_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class CodeSchoolTest < ActiveSupport::TestCase
+  def setup
+    @code_school = build :code_school
+  end
+
+  test "is_partner should be present" do
+    @code_school.is_partner = true
+    assert @code_school.valid?
+  end
+end

--- a/test/models/code_schools_test.rb
+++ b/test/models/code_schools_test.rb
@@ -5,8 +5,7 @@ class CodeSchoolTest < ActiveSupport::TestCase
     @code_school = build :code_school
   end
 
-  test "is_partner should be present" do
-    @code_school.is_partner = true
-    assert @code_school.valid?
+  test "is_partner should be present and default to false" do
+    assert @code_school.is_partner == false
   end
 end


### PR DESCRIPTION
# Description of changes
 Add is_partner to the CodeSchool table. Defaulting to false and null false
 Add attr to serializer
 Add attr to strong params
 Update apiary docs
 Add spec illustrating presence
 Add attr to factory, default to false
 Creates a new rake task to set any existing, relevant CodeSchool records in prod to is_partner: true

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #275