### PR TITLE
315 bug zip not found

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -211,9 +211,11 @@ class User < ApplicationRecord
   private
 
   def zip_code_exists
-    return if longitude && latitude
+    return if zip =~ /(^\d{5}$)|(^\d{5}-\d{4}$)/
 
-    errors.add(:zip_code, 'not found')
+    if geocoded? && longitude.blank? && latitude.blank?
+      errors.add(:zip_code, 'not found')
+    end
   end
 
   def upcase_state

--- a/test/cassettes/user_test/accepts_zip_codes_in_format_of_or_.yml
+++ b/test/cassettes/user_test/accepts_zip_codes_in_format_of_or_.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=12345&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 21 Apr 2018 16:07:31 GMT
+      Expires:
+      - Sun, 22 Apr 2018 16:07:31 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '488'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cache-Control:
+      - public, max-age=86400
+      Age:
+      - '83'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "12345",
+                       "short_name" : "12345",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Schenectady",
+                       "short_name" : "Schenectady",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Rotterdam",
+                       "short_name" : "Rotterdam",
+                       "types" : [ "administrative_area_level_3", "political" ]
+                    },
+                    {
+                       "long_name" : "Schenectady County",
+                       "short_name" : "Schenectady County",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "New York",
+                       "short_name" : "NY",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United States",
+                       "short_name" : "US",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Schenectady, NY 12345, USA",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : 42.8140012,
+                       "lng" : -73.9814578
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 42.8153501802915,
+                          "lng" : -73.98010881970849
+                       },
+                       "southwest" : {
+                          "lat" : 42.8126522197085,
+                          "lng" : -73.9828067802915
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJy_THIQZu3okR5Vhd3NrTQI8",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 21 Apr 2018 16:08:58 GMT
+recorded_with: VCR 3.0.3

--- a/test/cassettes/user_test/does_not_accept_invalid_zip_codes_when_geocoding_is_working.yml
+++ b/test/cassettes/user_test/does_not_accept_invalid_zip_codes_when_geocoding_is_working.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=a&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 21 Apr 2018 16:36:16 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '224'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "error_message" : "You have exceeded your daily request quota for this API. We recommend registering for a key at the Google Developers Console: https://console.developers.google.com/apis/credentials?project=_",
+           "results" : [],
+           "status" : "OVER_QUERY_LIMIT"
+        }
+    http_version: 
+  recorded_at: Sat, 21 Apr 2018 16:36:16 GMT
+recorded_with: VCR 3.0.3

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -60,6 +60,23 @@ class UserTest < ActiveSupport::TestCase
     assert_equal -0.4447103, u.longitude
   end
 
+  test 'accepts zip codes in format of 12345 or 12345-1234' do
+    user = create :user, zip: '12345', latitude: nil, longitude: nil
+
+    assert user.valid?
+  end
+
+  test 'does not accept invalid zip codes when geocoding is working' do
+    user = build :user, zip: 'a', latitude: nil, longitude: nil
+
+    user.stubs(:geocoded?).returns(true)
+    user.stubs(:latitude).returns(nil)
+    user.stubs(:longitude).returns(nil)
+
+    refute user.valid?
+    assert user.errors.full_messages == ["Zip code not found"]
+  end
+
   test 'longitude and longitude are nil for unknown zipcodes' do
     u = build(:user, latitude: nil, longitude: nil, zip: nil)
 


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Some users are getting an zip code error when creating a new account, potentially due to sporadic behavior from the geocoding API calls.

Here is the logic in this PR that addresses this:

If a zip is a number, that is either of these formats, `'12345'` or `'12345-1234'`, it is valid.

If it is not in one of those formats, and geocoding **is** working, and geocoding cannot find the zip code anywhere in the world, it is invalid.

If geocoding is not working, it accepts the passed zip code.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #315 
