### PR TITLE
321 grant py bot api access

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1063,6 +1063,41 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                 errors: "Some error message"
             }
 
+## Slack User | Access [/api/v1/slack_users/access]
+
+### Health check to confirm access [GET]
+
++ Request (application/json)
+
+    + Headers
+
+            Authorization: Bearer Access-Token
+
++ Response 200 (application/json)
+
+    + Body
+
+            {
+                message: "You have access!"
+            }
+
++ Response 401 (application/json)
+
+        {
+            errors: ["Auth token is incorrect"]
+        }
+
+        /* or*/
+
+        {
+            errors: ["Auth token has expired"]
+        }
+
+        /* or*/
+
+        {
+            errors: ["Invalid auth token"]
+        }
 
 ## Slack User | Invite [/api/v1/slack_users]
 

--- a/app/controllers/api/v1/slack_users_controller.rb
+++ b/app/controllers/api/v1/slack_users_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class SlackUsersController < ApiController
-      before_action :authenticate_user!
+      before_action :authenticate_py_bot!
 
       def create
         raise "User id #{current_user.id} does not have a saved email address." unless current_user.email.present?
@@ -11,6 +11,31 @@ module Api
         render json: { status: :ok }
       rescue StandardError => e
         render json: { errors: e.message }, status: :unprocessable_entity
+      end
+
+      def access
+        render json: { message: 'You have access!' }, status: :ok
+      end
+
+      private
+
+      def authenticate_py_bot!
+        auth = JsonWebToken.decode(auth_token)
+
+        if auth['key'] == Rails.application.secrets.py_bot_auth_key
+          true
+        else
+          render json: { errors: ["Auth token is incorrect"] }, status: :unauthorized
+        end
+
+      rescue JWT::ExpiredSignature
+        render json: { errors: ["Auth token has expired"] }, status: :unauthorized
+      rescue JWT::DecodeError
+        render json: { errors: ["Invalid auth token"] }, status: :unauthorized
+      end
+
+      def auth_token
+        @auth_token ||= request.headers.fetch('Authorization', '').split(' ').last
       end
     end
   end

--- a/app/controllers/api/v1/slack_users_controller.rb
+++ b/app/controllers/api/v1/slack_users_controller.rb
@@ -4,13 +4,7 @@ module Api
       before_action :authenticate_py_bot!
 
       def create
-        raise "User id #{current_user.id} does not have a saved email address." unless current_user.email.present?
-
-        SlackJobs::InviterJob.perform_now current_user.email
-
-        render json: { status: :ok }
-      rescue StandardError => e
-        render json: { errors: e.message }, status: :unprocessable_entity
+        # TODO: Placeholder for PyBot call to create new record
       end
 
       def access

--- a/app/controllers/api/v1/slack_users_controller.rb
+++ b/app/controllers/api/v1/slack_users_controller.rb
@@ -18,14 +18,11 @@ module Api
 
         if auth['key'] == Rails.application.secrets.py_bot_auth_key
           true
+        elsif auth.dig(:errors).present?
+          render json: { errors: auth.dig(:errors) }, status: :unauthorized
         else
-          render json: { errors: ["Auth token is incorrect"] }, status: :unauthorized
+          render json: { errors: ["Auth token is invalid"] }, status: :unauthorized
         end
-
-      rescue JWT::ExpiredSignature
-        render json: { errors: ["Auth token has expired"] }, status: :unauthorized
-      rescue JWT::DecodeError
-        render json: { errors: ["Invalid auth token"] }, status: :unauthorized
       end
 
       def auth_token

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -14,6 +14,10 @@ class JsonWebToken
     decoded_token = JWT.decode(token, Rails.application.secrets.jwt_secret)
 
     decoded_token.first
+  rescue JWT::ExpiredSignature
+    { errors: ["Auth token has expired"], status: 401 }
+  rescue JWT::DecodeError
+    { errors: ["Invalid auth token"], status: 401 }
   rescue => e
     Rails.logger.debug "Failed to decode token: '#{token}'"
     Rails.logger.debug e

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,6 @@ Rails.application.routes.draw do
       end
       resources :email_list_recipients, only: :create
       resources :events, only: :index
-      resource :social_users, only: [:create, :show]
       resources :mentors, only: [:index, :create, :show]
       resources :requests, only: [:index, :create, :show, :update]
       resources :resources, only: [:index, :create, :show, :update, :destroy] do
@@ -35,7 +34,12 @@ Rails.application.routes.draw do
       resources :scholarships, only: [:index, :show]
       resources :scholarship_applications, only: :create
       resources :services, only: :index
-      resources :slack_users, only: :create
+      resources :slack_users, only: :create do
+        collection do
+          get :access
+        end
+      end
+      resource :social_users, only: [:create, :show]
       resources :tags, only: :index
       resources :team_members, only: [:index, :create, :update, :destroy]
       resources :users, only: [:index, :create]

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -16,6 +16,7 @@ development:
   secret_key_base: 5d44826022fd9ef943fa7d5dcaf76722893b63e264fd8b3d22174992a001ed0bd8bb91131928d9ab2d25b6eccce54ebca320a7676942d05ae3defe96e2f04346
   jwt_secret: 'super random key'
   jwt_expiration_hours: 24
+  py_bot_auth_key: 'some random key'
 
 test:
   secret_key_base: 5a8beb5fc0bf57a8641d0720091190160f725c9063192cf33a0389524ed1dab63527880287c88fd6a3a3b42435cbc0693ce2fec233052bfe6648350c1d0df971
@@ -30,3 +31,5 @@ production:
   secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
   jwt_secret: <%= ENV['JWT_SECRET_KEY'] %>
   jwt_expiration_hours: 6
+  py_bot_auth_key: <%= ENV['PY_BOT_AUTH_KEY'] %>
+

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,23 +13,24 @@
 development:
   forest_env_secret: <%= ENV["DEV_FOREST_ENV_SECRET"] %>
   forest_auth_secret: <%= ENV["DEV_FOREST_AUTH_SECRET"] %>
-  secret_key_base: 5d44826022fd9ef943fa7d5dcaf76722893b63e264fd8b3d22174992a001ed0bd8bb91131928d9ab2d25b6eccce54ebca320a7676942d05ae3defe96e2f04346
   jwt_secret: 'super random key'
   jwt_expiration_hours: 24
   py_bot_auth_key: 'some random key'
+  secret_key_base: 5d44826022fd9ef943fa7d5dcaf76722893b63e264fd8b3d22174992a001ed0bd8bb91131928d9ab2d25b6eccce54ebca320a7676942d05ae3defe96e2f04346
 
 test:
-  secret_key_base: 5a8beb5fc0bf57a8641d0720091190160f725c9063192cf33a0389524ed1dab63527880287c88fd6a3a3b42435cbc0693ce2fec233052bfe6648350c1d0df971
   jwt_secret: 'super random test key'
   jwt_expiration_hours: 24
+  py_bot_auth_key: 'some random key'
+  secret_key_base: 5a8beb5fc0bf57a8641d0720091190160f725c9063192cf33a0389524ed1dab63527880287c88fd6a3a3b42435cbc0693ce2fec233052bfe6648350c1d0df971
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   forest_env_secret: <%= ENV["FOREST_ENV_SECRET"] %>
   forest_auth_secret: <%= ENV["FOREST_AUTH_SECRET"] %>
-  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
   jwt_secret: <%= ENV['JWT_SECRET_KEY'] %>
   jwt_expiration_hours: 6
   py_bot_auth_key: <%= ENV['PY_BOT_AUTH_KEY'] %>
+  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
 

--- a/test/controllers/api/v1/slack_users_controller_test.rb
+++ b/test/controllers/api/v1/slack_users_controller_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class Api::V1::SlackUsersControllerTest < ActionDispatch::IntegrationTest
+  test ':access confirms the passed token is equal to the secrets.py_bot_auth_key' do
+    token = JsonWebToken.encode({ key: Rails.application.secrets.py_bot_auth_key })
+
+    get access_api_v1_slack_users_url,
+      headers: auth_headers(token),
+      as: :json
+
+    body = JSON.parse(response.body)
+
+    assert response.status == 200
+    assert body == { "message" => "You have access!" }
+  end
+
+  test ':access returns a 401 with an incorrect token' do
+    invalid_token = JsonWebToken.encode({ key: 'an invalid token' })
+
+    get access_api_v1_slack_users_url,
+      headers: auth_headers(invalid_token),
+      as: :json
+
+    body = JSON.parse(response.body)
+
+    assert response.status == 401
+    assert body == { "errors" => ["Auth token is invalid"] }
+  end
+
+  test ':access returns a 401 with an expired token' do
+    expired_token = JsonWebToken.encode({ key: 'an expired token' }, 0)
+
+    get access_api_v1_slack_users_url,
+      headers: auth_headers(expired_token),
+      as: :json
+
+    body = JSON.parse(response.body)
+
+    assert response.status == 401
+    assert body == { "errors" => ["Auth token has expired"] }
+  end
+
+  test ':access returns a 401 with a malformed token' do
+    malformed_token = "a malformed token"
+
+    get access_api_v1_slack_users_url,
+      headers: auth_headers(malformed_token),
+      as: :json
+
+    body = JSON.parse(response.body)
+
+    assert response.status == 401
+    assert body == { "errors" => ["Invalid auth token"] }
+  end
+end
+
+def auth_headers(token)
+  { 'Authorization': "bearer #{token}" }
+end


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
This PR:

- Creates a `py_bot_auth_key` in the `config/secrets.yml`:
  - In the dev area, set to 'some_secret_key'
  - In prod, set to `<%= ENV["PY_BOT_AUTH_KEY"] %>`
- In kubernetes, set the auth key
- Creates a new 'health check/access' BE endpoint:
  - `/api/v1/slack_users/access`
  - Calls the JWT method to decode the key
  - If it is valid, that gives access to endpoint
  - Else raise, renders error

### PyBot workflow

- I will give @wimo7083 a JWT encoded version of the key 
- This will need to be passed in the auth headers for every request from PyBot (i.e. `Authorization: Bearer <encoded token>`)
- PyBot calls the new BE endpoints 
- BE confirms the validity of the token, and responds with the requested payload

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #321 
