### PR TITLE
Favors Rails secrets for auth config

### DIFF
--- a/app/lib/git_hub/settings.rb
+++ b/app/lib/git_hub/settings.rb
@@ -30,11 +30,11 @@ module GitHub
     end
 
     def self.client_id
-      OperationCode.fetch_secret_with(name: :git_hub_client_id)
+      Rails.application.secrets.git_hub_client_id
     end
 
     def self.client_secret
-      OperationCode.fetch_secret_with(name: :git_hub_client_secret)
+      Rails.application.secrets.git_hub_client_secret
     end
 
     # There are three ways to authenticate through GitHub's API v3.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,12 +13,16 @@
 development:
   forest_env_secret: <%= ENV["DEV_FOREST_ENV_SECRET"] %>
   forest_auth_secret: <%= ENV["DEV_FOREST_AUTH_SECRET"] %>
+  git_hub_client_id: 'some random id'
+  git_hub_client_secret: 'some random key'
   jwt_secret: 'super random key'
   jwt_expiration_hours: 24
   py_bot_auth_key: 'some random key'
   secret_key_base: 5d44826022fd9ef943fa7d5dcaf76722893b63e264fd8b3d22174992a001ed0bd8bb91131928d9ab2d25b6eccce54ebca320a7676942d05ae3defe96e2f04346
 
 test:
+  git_hub_client_id: 'some random id'
+  git_hub_client_secret: 'some random key'
   jwt_secret: 'super random test key'
   jwt_expiration_hours: 24
   py_bot_auth_key: 'some random key'
@@ -29,6 +33,8 @@ test:
 production:
   forest_env_secret: <%= ENV["FOREST_ENV_SECRET"] %>
   forest_auth_secret: <%= ENV["FOREST_AUTH_SECRET"] %>
+  git_hub_client_id: <%= ENV["GIT_HUB_CLIENT_ID"] %>
+  git_hub_client_secret: <%= ENV["GIT_HUB_CLIENT_SECRET"] %>
   jwt_secret: <%= ENV['JWT_SECRET_KEY'] %>
   jwt_expiration_hours: 6
   py_bot_auth_key: <%= ENV['PY_BOT_AUTH_KEY'] %>

--- a/run/secrets/git_hub_client_id
+++ b/run/secrets/git_hub_client_id
@@ -1,1 +1,0 @@
-fake_git_hub_client_id

--- a/run/secrets/git_hub_client_secret
+++ b/run/secrets/git_hub_client_secret
@@ -1,1 +1,0 @@
-fake_git_hub_client_secret

--- a/test/lib/git_hub/authentication_test.rb
+++ b/test/lib/git_hub/authentication_test.rb
@@ -35,8 +35,8 @@ class GitHub::AuthenticationTest < ActiveSupport::TestCase
     assert @instance.set_options == {
       :query =>
         {
-          :client_id => "fake_git_hub_client_id",
-          :client_secret => "fake_git_hub_client_secret",
+          :client_id => "some random id",
+          :client_secret => "some random key",
           :per_page => 100
         },
       :headers =>


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
In order to utilize the [aggregated GitHub stats feature](https://github.com/OperationCode/operationcode_backend/pull/153), we need the [GitHub authentication](https://developer.github.com/v3/#authentication) `client_id` and `client_secret` set.

# Definition of Done
- [x] Add GitHub `client_id` and `client_secret` values to Kubernetes
- [x] Remove old GitHub secrets implementation 


# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #335 
