### PR TITLE
Updates GitHub aggregation strategy to OAuth 2 token 

### DIFF
--- a/app/lib/git_hub/authentication.rb
+++ b/app/lib/git_hub/authentication.rb
@@ -24,10 +24,18 @@ module GitHub
       when BASIC
         # tbd
       when O_AUTH_2_TOKEN
-        # tbd
+        o_auth_2_token_options
       when O_AUTH_2_KEY_SECRET
         key_secret_options
       end
+    end
+
+    def o_auth_2_token_options
+      {
+        headers: {
+          'Authorization' => "Bearer #{GitHub::Settings.o_auth_2_token}"
+        }
+      }
     end
 
     def key_secret_options

--- a/app/lib/git_hub/settings.rb
+++ b/app/lib/git_hub/settings.rb
@@ -37,6 +37,10 @@ module GitHub
       Rails.application.secrets.git_hub_client_secret
     end
 
+    def self.o_auth_2_token
+      Rails.application.secrets.git_hub_oauth_token
+    end
+
     # There are three ways to authenticate through GitHub's API v3.
     # Choices are: BASIC, O_AUTH_2_TOKEN, or O_AUTH_2_KEY_SECRET.
     #
@@ -46,7 +50,7 @@ module GitHub
     # @see https://developer.github.com/v3/#authentication
     #
     def self.authentication_level
-      GitHub::Authentication::O_AUTH_2_KEY_SECRET
+      GitHub::Authentication::O_AUTH_2_TOKEN
     end
   end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,6 +13,7 @@
 development:
   git_hub_client_id: 'some random id'
   git_hub_client_secret: 'some random key'
+  git_hub_oauth_token: 'some_random_token'
   jwt_secret: 'super random key'
   jwt_expiration_hours: 24
   py_bot_auth_key: 'some random key'
@@ -21,6 +22,7 @@ development:
 test:
   git_hub_client_id: 'some random id'
   git_hub_client_secret: 'some random key'
+  git_hub_oauth_token: 'some_random_token'
   jwt_secret: 'super random test key'
   jwt_expiration_hours: 24
   py_bot_auth_key: 'some random key'
@@ -31,6 +33,7 @@ test:
 production:
   git_hub_client_id: <%= ENV["GIT_HUB_CLIENT_ID"] %>
   git_hub_client_secret: <%= ENV["GIT_HUB_CLIENT_SECRET"] %>
+  git_hub_oauth_token: <%= ENV["GIT_HUB_OAUTH_TOKEN"] %>
   jwt_secret: <%= ENV['JWT_SECRET_KEY'] %>
   jwt_expiration_hours: 6
   py_bot_auth_key: <%= ENV['PY_BOT_AUTH_KEY'] %>

--- a/test/lib/git_hub/authentication_test.rb
+++ b/test/lib/git_hub/authentication_test.rb
@@ -61,7 +61,7 @@ class GitHub::AuthenticationTest < ActiveSupport::TestCase
         {
           "Accepts" => "application/vnd.github.v3+json",
           "User-Agent" => "operationcode",
-          "Authorization" => "Bearer #{Rails.application.secrets.git_hub_oauth_token}"
+          "Authorization" => "Bearer #{GitHub::Settings.o_auth_2_token}"
         }
       }
   end

--- a/test/lib/git_hub/authentication_test.rb
+++ b/test/lib/git_hub/authentication_test.rb
@@ -29,7 +29,7 @@ class GitHub::AuthenticationTest < ActiveSupport::TestCase
     assert @instance.set_options == @options
   end
 
-  test "#set_options merges the authenticated options hash when Rails.env.prod? is true" do
+  test "#set_options merges the authenticated OAUTH_KEY options hash when Rails.env.prod? is true" do
     Rails.env.stubs(:prod?).returns(true)
 
     assert @instance.set_options == {
@@ -43,6 +43,25 @@ class GitHub::AuthenticationTest < ActiveSupport::TestCase
         {
           "Accepts" => "application/vnd.github.v3+json",
           "User-Agent" => "operationcode"
+        }
+      }
+  end
+
+  test "#set_options merges the authenticated OAUTH_TOKEN options hash when Rails.env.prod? is true" do
+    GitHub::Settings.stubs(:authentication_level).returns(GitHub::Authentication::O_AUTH_2_TOKEN)
+    Rails.env.stubs(:prod?).returns(true)
+
+    instance = GitHub::Authentication.new(@options)
+    assert instance.set_options == {
+      :query =>
+        {
+          :per_page => 100
+        },
+      :headers =>
+        {
+          "Accepts" => "application/vnd.github.v3+json",
+          "User-Agent" => "operationcode",
+          "Authorization" => "Bearer #{Rails.application.secrets.git_hub_oauth_token}"
         }
       }
   end


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
The [O_AUTH_2_KEY_SECRET](https://developer.github.com/v3/#authentication) strategy was capping our rate limit at 60 (vs. 5000).

This PR updates the strategy to `O_AUTH_2_TOKEN`.