### PR TITLE
Rubocop style string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,8 @@
 inherit_from: .rubocop_todo.yml
+
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
+# SupportedStyles: single_quotes, double_quotes
+Style/StringLiterals:
+  Exclude:
+    - 'db/**/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -732,13 +732,6 @@ Style/StabbyLambdaParentheses:
   Exclude:
     - 'app/models/git_hub_statistic.rb'
 
-# Offense count: 991
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 27
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, MinSize.

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 source 'https://rubygems.org'
 
 git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
   "https://github.com/#{repo_name}.git"
 end
 

--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -6,7 +6,7 @@ ActiveAdmin.register AdminUser do
     id_column
     column :email
 
-    column "Role" do |admin_user|
+    column 'Role' do |admin_user|
       admin_user.role.title
     end
 

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,10 +1,10 @@
-ActiveAdmin.register_page "Dashboard" do
-  menu priority: 1, label: proc{ I18n.t("active_admin.dashboard") }
+ActiveAdmin.register_page 'Dashboard' do
+  menu priority: 1, label: proc{ I18n.t('active_admin.dashboard') }
 
-  content title: proc{ I18n.t("active_admin.dashboard") } do
+  content title: proc{ I18n.t('active_admin.dashboard') } do
     columns do
       column do
-        panel "New User Counts" do
+        panel 'New User Counts' do
           para "Today: #{User.count_created_since(Date.today)}"
           para "In the last week: #{User.count_created_since(1.week.ago)}"
           para "In the last month: #{User.count_created_since(1.month.ago)}"
@@ -13,7 +13,7 @@ ActiveAdmin.register_page "Dashboard" do
       end
 
       column do
-        panel "Verified Users" do
+        panel 'Verified Users' do
           para User.verified.count
         end
       end

--- a/app/admin/location.rb
+++ b/app/admin/location.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register Location do
     selectable_column
     id_column
 
-    column "Code School" do |location|
+    column 'Code School' do |location|
       location.code_school.name
     end
 

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -45,7 +45,7 @@ module Api
         @sso.username = current_user.email
         @sso.external_id = current_user.id
         @sso.custom_fields['verified'] = current_user.verified
-        @sso.add_groups = "mentors" if current_user.mentor
+        @sso.add_groups = 'mentors' if current_user.mentor
         @sso.sso_secret = Discourse::SingleSignOn::SECRET
 
         @redirect_path = @sso.to_url('https://community.operationcode.org/session/sso_login')

--- a/app/controllers/api/v1/slack_users_controller.rb
+++ b/app/controllers/api/v1/slack_users_controller.rb
@@ -21,7 +21,7 @@ module Api
         elsif auth.dig(:errors).present?
           render json: { errors: auth.dig(:errors) }, status: :unauthorized
         else
-          render json: { errors: ["Auth token is invalid"] }, status: :unauthorized
+          render json: { errors: ['Auth token is invalid'] }, status: :unauthorized
         end
       end
 

--- a/app/controllers/api/v1/users/passwords_controller.rb
+++ b/app/controllers/api/v1/users/passwords_controller.rb
@@ -10,7 +10,7 @@ module Api
         def reset
           user = User.find_by email: params[:email]
 
-          raise "Could not find a user with that email address" unless user.present?
+          raise 'Could not find a user with that email address' unless user.present?
           user.send_reset_password_instructions
 
           render json: { status: :ok }

--- a/app/lib/discourse/single_sign_on.rb
+++ b/app/lib/discourse/single_sign_on.rb
@@ -17,11 +17,11 @@ module Discourse
     attr_accessor :sso_secret, :sso_url
 
     def self.sso_secret
-      raise RuntimeError, "sso_secret not implemented on class, be sure to set it on instance"
+      raise RuntimeError, 'sso_secret not implemented on class, be sure to set it on instance'
     end
 
     def self.sso_url
-      raise RuntimeError, "sso_url not implemented on class, be sure to set it on instance"
+      raise RuntimeError, 'sso_url not implemented on class, be sure to set it on instance'
     end
 
     def self.parse(payload, sso_secret = nil)
@@ -44,7 +44,7 @@ module Discourse
         val = decoded_hash[k.to_s]
         val = val.to_i if FIXNUMS.include? k
         if BOOLS.include? k
-          val = ["true", "false"].include?(val) ? val == "true" : nil
+          val = ['true', 'false'].include?(val) ? val == 'true' : nil
         end
         sso.send("#{k}=", val)
       end
@@ -75,7 +75,7 @@ module Discourse
     end
 
     def sign(payload)
-      OpenSSL::HMAC.hexdigest("sha256", sso_secret, payload)
+      OpenSSL::HMAC.hexdigest('sha256', sso_secret, payload)
     end
 
     def to_url(base_url=nil)

--- a/app/lib/git_hub/client.rb
+++ b/app/lib/git_hub/client.rb
@@ -1,4 +1,4 @@
-require "httparty"
+require 'httparty'
 
 module GitHub
 
@@ -118,7 +118,7 @@ module GitHub
     def reset_time(response)
       seconds = response.headers['X-RateLimit-Reset'].to_i
 
-      Time.at(seconds).strftime "%-m/%d/%Y at%l:%M:%S%P %Z"
+      Time.at(seconds).strftime '%-m/%d/%Y at%l:%M:%S%P %Z'
     end
   end
 end

--- a/app/lib/git_hub/issues.rb
+++ b/app/lib/git_hub/issues.rb
@@ -50,7 +50,7 @@ module GitHub
       }
       response = client.search_for(query)
 
-      if response.headers["link"].present?
+      if response.headers['link'].present?
         GitHub::PageCompiler.new(query, response, client).compile_prs
       else
         response['items']

--- a/app/lib/git_hub/page_compiler.rb
+++ b/app/lib/git_hub/page_compiler.rb
@@ -43,7 +43,7 @@ module GitHub
     private
 
     def pages_in(response)
-      pages = response.headers["link"].split(",").last.match(/&page=(\d+).*$/)[1]
+      pages = response.headers['link'].split(',').last.match(/&page=(\d+).*$/)[1]
 
       pages.to_i
     end

--- a/app/lib/git_hub/pull_requests.rb
+++ b/app/lib/git_hub/pull_requests.rb
@@ -50,7 +50,7 @@ module GitHub
       }
       response = client.search_for(query)
 
-      if response.headers["link"].present?
+      if response.headers['link'].present?
         GitHub::PageCompiler.new(query, response, client).compile_prs
       else
         response['items']
@@ -77,7 +77,7 @@ module GitHub
       response = client.commits_for(repo, pull_request_number)
       query    = { repo: repo, pr_number: pull_request_number }
 
-      if response.headers["link"].present?
+      if response.headers['link'].present?
         GitHub::PageCompiler.new(query, response, client).compile_commits
       else
         response.parsed_response

--- a/app/lib/id_me.rb
+++ b/app/lib/id_me.rb
@@ -1,4 +1,4 @@
-require "httparty"
+require 'httparty'
 
 class IdMe
   include HTTParty

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -15,9 +15,9 @@ class JsonWebToken
 
     decoded_token.first
   rescue JWT::ExpiredSignature
-    { errors: ["Auth token has expired"], status: 401 }
+    { errors: ['Auth token has expired'], status: 401 }
   rescue JWT::DecodeError
-    { errors: ["Invalid auth token"], status: 401 }
+    { errors: ['Invalid auth token'], status: 401 }
   rescue => e
     Rails.logger.debug "Failed to decode token: '#{token}'"
     Rails.logger.debug e

--- a/app/lib/meetup.rb
+++ b/app/lib/meetup.rb
@@ -9,14 +9,14 @@ class Meetup
     @options = {
       query: {
       key: api_key,
-      sign: "true"
+      sign: 'true'
       }
     }
   end
 
   # GET all Operation Code Pro data. Returns all op-code groups.
   def operationcode_data
-    response = self.class.get("/pro/operationcode/groups", options)
+    response = self.class.get('/pro/operationcode/groups', options)
     return_value_for response
   end
 
@@ -40,7 +40,7 @@ class Meetup
 
   def add_events_to_database!
     event_details_by_group.each do |event|
-      saved_event = Event.find_or_initialize_by(source_id: event[:source_id], source_type: "Meetup")
+      saved_event = Event.find_or_initialize_by(source_id: event[:source_id], source_type: 'Meetup')
       if saved_event.new_record? || saved_event_updated?(saved_event, event)
         saved_event.update!(event)
       end
@@ -54,7 +54,7 @@ class Meetup
   end
 
   def group_names
-    operationcode_data.map { |group| group["urlname"] }
+    operationcode_data.map { |group| group['urlname'] }
   end
 
   def event_duration(event)
@@ -69,7 +69,7 @@ class Meetup
     if response.code.to_i == 200
       response.parsed_response
     else
-      raise "Error fetching data from Meetup API"
+      raise 'Error fetching data from Meetup API'
     end
   end
 
@@ -90,7 +90,7 @@ class Meetup
       state: event['venue']['state'],
       zip: event['venue']['zip'],
       group: event['group']['name'],
-      source_type: "Meetup"
+      source_type: 'Meetup'
     }
   end
 end

--- a/app/lib/seed_team_members.rb
+++ b/app/lib/seed_team_members.rb
@@ -1,9 +1,9 @@
 class SeedTeamMembers
-  BOARD_DATA_PATH = "board_members.yml".freeze
-  TEAM_DATA_PATH = "team_members.yml".freeze
+  BOARD_DATA_PATH = 'board_members.yml'.freeze
+  TEAM_DATA_PATH = 'team_members.yml'.freeze
   class << self
     def from_yaml(file_name, group)
-      members_seed_file = Rails.root.join("config", file_name)
+      members_seed_file = Rails.root.join('config', file_name)
       members = YAML.load_file(members_seed_file)
       members.each do |member|
         create_or_update(member.merge(group: group))
@@ -37,7 +37,7 @@ class SeedTeamMembers
     private
 
     def create_or_update(member)
-      TeamMember.find_or_create_by!(name: member["name"]) do |c|
+      TeamMember.find_or_create_by!(name: member['name']) do |c|
         c.update!(member)
       end
     end

--- a/app/lib/send_grid_client.rb
+++ b/app/lib/send_grid_client.rb
@@ -35,32 +35,32 @@ class SendGridClient
     Rails.logger.info("Sending email to #{options[:to]} at #{Time.current} re: #{options[:subject]}")
 
     mail = {
-      "personalizations" => [
+      'personalizations' => [
         {
-          "to" => [
+          'to' => [
             {
-              "email" => options[:to]
+              'email' => options[:to]
             }
           ],
-          "subject" => options[:subject],
-          "substitutions" => {
-            "-user_count-" => options[:user_count].to_s
+          'subject' => options[:subject],
+          'substitutions' => {
+            '-user_count-' => options[:user_count].to_s
           },
-          "template_id" => options[:transactional_template_id]
+          'template_id' => options[:transactional_template_id]
         }
       ],
-      "from" => {
-        "email" => options[:from]
+      'from' => {
+        'email' => options[:from]
       },
-      "content" => [
+      'content' => [
         {
-          "type" => "text/plain",
-          "value" => options[:body]
+          'type' => 'text/plain',
+          'value' => options[:body]
         }
       ]
     }
 
-    @sendgrid.client.mail._("send").post(request_body: mail)
+    @sendgrid.client.mail._('send').post(request_body: mail)
   rescue => e
     Rails.logger.error "Failed to send email to #{options[:to]} re: #{options[:subject]} due to: #{e}"
     Rails.logger.error e.backtrace.join("\n")

--- a/app/lib/slack/client.rb
+++ b/app/lib/slack/client.rb
@@ -1,4 +1,4 @@
-require "net/http"
+require 'net/http'
 
 module Slack
   INVITE_PATH = '/api/users.admin.invite'.freeze
@@ -26,13 +26,13 @@ module Slack
         to: INVITE_PATH,
         payload: {
           email:       email,
-          channels:    channels.join(","),
+          channels:    channels.join(','),
           token:       @token,
-          set_active:  "true",
+          set_active:  'true',
           _attempts:   1
         }
       )
-      if !(body["ok"] || %w(already_in_team already_invited sent_recently).include?(body["error"]))
+      if !(body['ok'] || %w(already_in_team already_invited sent_recently).include?(body['error']))
         raise InviteFailed.new(body.to_s)
       end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,11 +3,11 @@ class UserMailer < ActionMailer::Base
 
   def welcome(user)
     @user = user
-    mail to: @user.email, subject: "Welcome to Operation Code!"
+    mail to: @user.email, subject: 'Welcome to Operation Code!'
   end
 
   def new_user_in_leader_area(leader, new_user)
     @new_user = new_user
-    mail to: leader.email, subject: "A new user has joined within 50 miles of you"
+    mail to: leader.email, subject: 'A new user has joined within 50 miles of you'
   end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -9,7 +9,7 @@ class Resource < ApplicationRecord
   #
   # @see https://github.com/mbleigh/acts-as-taggable-on#usage
   #
-  def self.with_tags(tags="")
+  def self.with_tags(tags='')
     if tags.present?
       tagged_with(tags, any: true, parse: true)
     else

--- a/app/models/scholarship_application.rb
+++ b/app/models/scholarship_application.rb
@@ -11,7 +11,7 @@ class ScholarshipApplication < ApplicationRecord
 
   def user_is_verified
     unless self.user_verified
-      errors.add(:verified, "Only verified users may submit applications")
+      errors.add(:verified, 'Only verified users may submit applications')
     end
   end
 end

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -1,7 +1,7 @@
 class TeamMember < ApplicationRecord
-  BOARD_GROUP_NAME = "board".freeze
-  EXECUTIVE_GROUP_NAME = "executive".freeze
-  TEAM_GROUP_NAME = "team".freeze
+  BOARD_GROUP_NAME = 'board'.freeze
+  EXECUTIVE_GROUP_NAME = 'executive'.freeze
+  TEAM_GROUP_NAME = 'team'.freeze
 
   validates :name, :role, :group, presence: true
   validates :group, inclusion: {

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -3,5 +3,5 @@ class Vote < ApplicationRecord
   belongs_to :resource, counter_cache: true
 
   validates :user_id, :resource_id, presence: true
-  validates :user_id, uniqueness: { scope: :resource_id, message: "has already voted for this resource" }
+  validates :user_id, uniqueness: { scope: :resource_id, message: 'has already voted for this resource' }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,16 +1,16 @@
 require_relative 'boot'
 
-require "rails"
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_view/railtie"
-require "action_cable/engine"
-require "sprockets/railtie"
-require "rails/test_unit/railtie"
+require 'active_model/railtie'
+require 'active_job/railtie'
+require 'active_record/railtie'
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+require 'action_view/railtie'
+require 'action_cable/engine'
+require 'sprockets/railtie'
+require 'rails/test_unit/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -4,7 +4,7 @@ ActiveAdmin.setup do |config|
   # Set the title that is displayed on the main layout
   # for each of the active admin pages.
   #
-  config.site_title = "Operation Code"
+  config.site_title = 'Operation Code'
 
   # Set the link url for the title. For example, to take
   # users to your main site. Defaults to no link.

--- a/config/initializers/core_extensions/devise/strategies/json_web_token.rb
+++ b/config/initializers/core_extensions/devise/strategies/json_web_token.rb
@@ -20,7 +20,7 @@ module Devise
         return nil unless valid_strategy?(strategy)
 
         claim = ::JsonWebToken.decode(token)
-        Rails.logger.debug "Claim decoded"
+        Rails.logger.debug 'Claim decoded'
         claim
       rescue => e
         Rails.logger.debug "Failed to decode token #{token}"

--- a/lib/tasks/git_hub.rake
+++ b/lib/tasks/git_hub.rake
@@ -1,5 +1,5 @@
 namespace :git_hub do
-  desc "Saves pull request, commit, issue and user details for all repositories to date, to GitHubStatistic and GitHubUser"
+  desc 'Saves pull request, commit, issue and user details for all repositories to date, to GitHubStatistic and GitHubUser'
   task collect_statistics: :environment do
     begin
       limit = GitHub::Client.new.rate_limit

--- a/lib/tasks/meetup.rake
+++ b/lib/tasks/meetup.rake
@@ -1,5 +1,5 @@
 namespace :meetup do
-  desc "Rake task to get Meetup API data"
+  desc 'Rake task to get Meetup API data'
   task :fetch => :environment do
     begin
       Meetup.new.add_events_to_database!

--- a/lib/tasks/roles.rake
+++ b/lib/tasks/roles.rake
@@ -1,5 +1,5 @@
 namespace :roles do
-  desc "Creates the initial set of roles"
+  desc 'Creates the initial set of roles'
   task initial_set: :environment do
     ['super_admin', 'admin', 'board_member'].each do |role|
       begin

--- a/lib/tasks/schools_from_yml.rake
+++ b/lib/tasks/schools_from_yml.rake
@@ -1,27 +1,27 @@
 namespace :schools do
-  desc "Reads from the ./config/code_schools.yml and creates records in the database."
+  desc 'Reads from the ./config/code_schools.yml and creates records in the database.'
   task populate: :environment do
-    schools =  YAML::load_file(File.join("./config", "code_schools.yml"), "r")
+    schools =  YAML::load_file(File.join('./config', 'code_schools.yml'), 'r')
     schools.each do |school|
       begin
         object = CodeSchool.create!(
-          name: school["name"],
-          url: school["url"],
-          logo: school["logo"],
-          full_time: school["full_time"],
-          hardware_included: school["hardware_included"],
-          has_online: school["has_online"],
-          online_only: school["online_only"],
-          notes: school["notes"]
+          name: school['name'],
+          url: school['url'],
+          logo: school['logo'],
+          full_time: school['full_time'],
+          hardware_included: school['hardware_included'],
+          has_online: school['has_online'],
+          online_only: school['online_only'],
+          notes: school['notes']
           )
-        school["locations"].each do |location|
+        school['locations'].each do |location|
           object.locations.create!(
-            va_accepted: location["va_accepted"],
-            address1: location["address1"],
-            address2: location["address2"],
-            city: location["city"],
-            state: location["state"],
-            zip: location["zip"]
+            va_accepted: location['va_accepted'],
+            address1: location['address1'],
+            address2: location['address2'],
+            city: location['city'],
+            state: location['state'],
+            zip: location['zip']
           )
         end
       rescue StandardError => e

--- a/lib/tasks/seed_members.rake
+++ b/lib/tasks/seed_members.rake
@@ -1,5 +1,5 @@
 namespace :seed_team_members do
-  desc "Seed team members"
+  desc 'Seed team members'
   task all: :environment do
     SeedTeamMembers.seed_all
   end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,8 +1,8 @@
 namespace :test do
-  task :policies => "test:prepare" do
-    $: << "test"
-    Minitest.rake_run(["test/policies"])
+  task :policies => 'test:prepare' do
+    $: << 'test'
+    Minitest.rake_run(['test/policies'])
   end
 end
 
-Rake::Task['test:run'].enhance ["test:policies"]
+Rake::Task['test:run'].enhance ['test:policies']

--- a/lib/tasks/update_is_partner_for_code_schools.rake
+++ b/lib/tasks/update_is_partner_for_code_schools.rake
@@ -1,16 +1,16 @@
 namespace :is_partner do
-  desc "Updates column is_partner for code schools"
+  desc 'Updates column is_partner for code schools'
   task code_schools: :environment do
     is_partner_schools = [
-                           "Bloc",
-                           "Coder Camps",
-                           "Code Platoon",
-                           "The Flatiron School",
-                           "Fullstack Academy",
-                           "Launch School",
-                           "Sabio",
-                           "Startup Institute",
-                           "Thinkful"
+                           'Bloc',
+                           'Coder Camps',
+                           'Code Platoon',
+                           'The Flatiron School',
+                           'Fullstack Academy',
+                           'Launch School',
+                           'Sabio',
+                           'Startup Institute',
+                           'Thinkful'
                           ]
                           
     schools = CodeSchool.where(name: is_partner_schools)

--- a/lib/tasks/update_sabio.rake
+++ b/lib/tasks/update_sabio.rake
@@ -1,9 +1,9 @@
 namespace :update do
-  desc "Updates the Sabio.jpg to Sabio.png"
+  desc 'Updates the Sabio.jpg to Sabio.png'
   task sabio: :environment do
-    school = CodeSchool.find_by(name: "Sabio")
+    school = CodeSchool.find_by(name: 'Sabio')
     logo = school.logo
-    logo[-3..-1] = "png"
+    logo[-3..-1] = 'png'
     school.save
   end
 end

--- a/lib/tasks/update_schools_logo.rake
+++ b/lib/tasks/update_schools_logo.rake
@@ -1,11 +1,11 @@
 namespace :update do
-  desc "Update code schools logo from github assets to AWS S3"
+  desc 'Update code schools logo from github assets to AWS S3'
   task school_logos: :environment do
     schools = CodeSchool.all
     schools.each do |school|
       logo = school.logo
-      if logo.include? "https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images"
-        new_logo = logo.sub("https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images", "https://s3.amazonaws.com/operationcode-assets")
+      if logo.include? 'https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images'
+        new_logo = logo.sub('https://raw.githubusercontent.com/OperationCode/operationcode_frontend/master/src/images', 'https://s3.amazonaws.com/operationcode-assets')
         
         school.logo = new_logo
         school.save

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -8,7 +8,7 @@ namespace :users do
     users = User.where.not(latitude: nil, longitude: nil).where(state: nil).limit(GEOCODING_DAILY_MAX)
     user_count = users.count
 
-    return "0 eligible users to be updated" unless users.present?
+    return '0 eligible users to be updated' unless users.present?
     p "#{user_count} users are eligible to be updated."
 
     users.in_batches(of: GEOCODING_PER_S_MAX).each_with_index do |batch, batch_index|
@@ -34,27 +34,27 @@ namespace :users do
     p "#{remaining} users left to be updated.  Task can be reran in 24 hours."
   end
 
-  desc "Tags select users as Community Leaders"
+  desc 'Tags select users as Community Leaders'
   task seed_leader: :environment do
     leaders = [
-               { first_name: "Jesse", last_name: "James", email: "jrjames.pdx@gmail.com" },
-               { first_name: "Vail", last_name: "Algatt", email: "vail.algatt@gmail.com" },
-               { first_name: "Toanh", last_name: "Tran", email: "toanh.t.tran@gmail.com" },
-               { first_name: "Billy", last_name: "Le", email: "lebilly87@gmail.com" },
-               { first_name: "Jameel", last_name: "Matin", email: "jameel.matin@gmail.com" },
-               { first_name: "David", last_name: "Wayne", email: "djwayne3@gmail.com" },
-               { first_name: "Stuart", last_name: "Ashby", email: "stu@codervets.org" },
-               { first_name: "Rod", last_name: "Levy", email: "rod@codeplatoon.org" },
-               { first_name: "Cherie", last_name: "Burgett", email: "cburgett@mmisac.org" },
-               { first_name: "Blair", last_name: "Coleman", email: "blairestellecoleman@gmail.com" },
-               { first_name: "Larry", last_name: "Burris", email: "larry.n.burris@gmail.com" },
-               { first_name: "Matthew", last_name: "Bach", email: "mbach04@gmail.com" },
-               { first_name: "Kerri-Leigh", last_name: "Grady", email: "klgrady@gmail.com" },
-               { first_name: "Sara", last_name: "Blaschke", email: "sara.blaschke@yahoo.com" },
-               { first_name: "Mercedes", last_name: "Welch", email: "thefamwelch@gmail.com" },
-               { first_name: "David", last_name: "Molina", email: "david@molinas.com" },
-               { first_name: "Conrad", last_name: "Hollomon", email: "conrad@operationcode.org" },
-               { first_name: "Krystyna", last_name: "Ewing", email: "krystyna@operationcode.org" }
+               { first_name: 'Jesse', last_name: 'James', email: 'jrjames.pdx@gmail.com' },
+               { first_name: 'Vail', last_name: 'Algatt', email: 'vail.algatt@gmail.com' },
+               { first_name: 'Toanh', last_name: 'Tran', email: 'toanh.t.tran@gmail.com' },
+               { first_name: 'Billy', last_name: 'Le', email: 'lebilly87@gmail.com' },
+               { first_name: 'Jameel', last_name: 'Matin', email: 'jameel.matin@gmail.com' },
+               { first_name: 'David', last_name: 'Wayne', email: 'djwayne3@gmail.com' },
+               { first_name: 'Stuart', last_name: 'Ashby', email: 'stu@codervets.org' },
+               { first_name: 'Rod', last_name: 'Levy', email: 'rod@codeplatoon.org' },
+               { first_name: 'Cherie', last_name: 'Burgett', email: 'cburgett@mmisac.org' },
+               { first_name: 'Blair', last_name: 'Coleman', email: 'blairestellecoleman@gmail.com' },
+               { first_name: 'Larry', last_name: 'Burris', email: 'larry.n.burris@gmail.com' },
+               { first_name: 'Matthew', last_name: 'Bach', email: 'mbach04@gmail.com' },
+               { first_name: 'Kerri-Leigh', last_name: 'Grady', email: 'klgrady@gmail.com' },
+               { first_name: 'Sara', last_name: 'Blaschke', email: 'sara.blaschke@yahoo.com' },
+               { first_name: 'Mercedes', last_name: 'Welch', email: 'thefamwelch@gmail.com' },
+               { first_name: 'David', last_name: 'Molina', email: 'david@molinas.com' },
+               { first_name: 'Conrad', last_name: 'Hollomon', email: 'conrad@operationcode.org' },
+               { first_name: 'Krystyna', last_name: 'Ewing', email: 'krystyna@operationcode.org' }
               ]
 
     email_array = leaders.map { |u| u[:email] }

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -5,19 +5,19 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     user = create(:user)
     @headers = authorization_headers(user)
     @school = create(:code_school)
-    @school.name = "CoderSchool"
+    @school.name = 'CoderSchool'
     @school.save
     @location = create(
       :location,
       code_school: @school,
-      address1: "2405 Nugget Lane"
+      address1: '2405 Nugget Lane'
     )
   end
 
   test ":validates CodeSchool's required fields" do
     params = {
       code_school: {
-        name: "CoderSchool"
+        name: 'CoderSchool'
       }
     }
     post api_v1_code_schools_url,
@@ -25,38 +25,38 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
       headers: @headers,
       as: :json
 
-    errors = JSON.parse(response.body)["errors"]
+    errors = JSON.parse(response.body)['errors']
     assert errors.include? "Url can't be blank"
   end
 
-  test ":index endpoint returns a JSON list of all CodeSchools" do
+  test ':index endpoint returns a JSON list of all CodeSchools' do
     get api_v1_code_schools_path, as: :json
 
     body = JSON.parse(response.body)[0]
-    locations = body["locations"]
-    assert_equal body["name"], "CoderSchool"
+    locations = body['locations']
+    assert_equal body['name'], 'CoderSchool'
     assert_not_nil locations
-    assert_not_nil locations.first["address1"]
-    assert_equal locations.first["address1"], "2405 Nugget Lane"
+    assert_not_nil locations.first['address1']
+    assert_equal locations.first['address1'], '2405 Nugget Lane'
   end
 
-  test ":index endpoint returns the mooc attriubte" do
+  test ':index endpoint returns the mooc attriubte' do
     get api_v1_code_schools_path, as: :json
 
     body = JSON.parse(response.body)[0]
 
-    assert body.keys.include? "mooc"
+    assert body.keys.include? 'mooc'
   end
 
-  test ":index endpoint sorts first by CodeSchool#name, second by Location#state, third by Location#city" do
+  test ':index endpoint sorts first by CodeSchool#name, second by Location#state, third by Location#city' do
     CodeSchool.destroy_all
 
-    wynode_academy = create :code_school, name: "Wynode Academy"
-    coding_dojo = create :code_school, name: "Coding Dojo"
-    wynode_dallas = create :location, code_school: wynode_academy, city: "Dallas", state: "TX"
-    wynode_denver = create :location, code_school: wynode_academy, city: "Denver", state: "CO"
-    dojo_san_fran = create :location, code_school: coding_dojo, city: "San Francisco", state: "CA"
-    dojo_la = create :location, code_school: coding_dojo, city: "Los Angeles", state: "CA"
+    wynode_academy = create :code_school, name: 'Wynode Academy'
+    coding_dojo = create :code_school, name: 'Coding Dojo'
+    wynode_dallas = create :location, code_school: wynode_academy, city: 'Dallas', state: 'TX'
+    wynode_denver = create :location, code_school: wynode_academy, city: 'Denver', state: 'CO'
+    dojo_san_fran = create :location, code_school: coding_dojo, city: 'San Francisco', state: 'CA'
+    dojo_la = create :location, code_school: coding_dojo, city: 'Los Angeles', state: 'CA'
 
     get api_v1_code_schools_path, as: :json
 
@@ -64,14 +64,14 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     dojo = code_schools[0]
     wynode = code_schools[1]
 
-    assert dojo["name"] == coding_dojo.name
-    assert wynode["name"] == wynode_academy.name
+    assert dojo['name'] == coding_dojo.name
+    assert wynode['name'] == wynode_academy.name
 
     assert cities_for(dojo) == [dojo_la.city, dojo_san_fran.city]
     assert cities_for(wynode) == [wynode_denver.city, wynode_dallas.city]
   end
 
-  test ":create endpoint creates a CodeSchool successfully" do
+  test ':create endpoint creates a CodeSchool successfully' do
     post api_v1_code_schools_path(@school),
       params: { code_school: @school },
       headers: @headers,
@@ -79,42 +79,42 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
-  test ":create endpoint responds unauthorized for unauthenticated user" do
+  test ':create endpoint responds unauthorized for unauthenticated user' do
     post api_v1_code_schools_path(@school),
       params: { code_school: @school },
       as: :json
     assert_response :unauthorized
   end
 
-  test ":show will not work for a invalid record" do
+  test ':show will not work for a invalid record' do
     get api_v1_code_school_path(99999999), as: :json
     assert_response :missing
   end
 
-  test ":show works for a valid record"do
+  test ':show works for a valid record'do
     get api_v1_code_school_path(@school), as: :json
     assert_response :ok
   end
 
-  test ":update endpoint updates an existing CodeSchool" do
+  test ':update endpoint updates an existing CodeSchool' do
     put api_v1_code_school_path(@school),
-      params: { name: "CoddderrrrSchool" },
+      params: { name: 'CoddderrrrSchool' },
       headers: @headers,
       as: :json
 
-    name = JSON.parse(response.body)["name"]
+    name = JSON.parse(response.body)['name']
     assert_equal response.status, 200
-    assert_equal name, "CoddderrrrSchool"
+    assert_equal name, 'CoddderrrrSchool'
   end
 
-  test ":update endpoint responds unauthorized for unauthenticated user" do
+  test ':update endpoint responds unauthorized for unauthenticated user' do
     put api_v1_code_school_path(@school),
-      params: { name: "CoddderrrrSchool" },
+      params: { name: 'CoddderrrrSchool' },
       as: :json
     assert_response :unauthorized
   end
 
-  test ":destroy endpoint destroys an existing CodeSchool" do
+  test ':destroy endpoint destroys an existing CodeSchool' do
     id = @school.id
 
     delete api_v1_code_school_path(@school), headers: @headers
@@ -124,12 +124,12 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     assert_response :missing
   end
 
-  test ":destroy endpoint responds unauthorized for unauthenticated user" do
+  test ':destroy endpoint responds unauthorized for unauthenticated user' do
     delete api_v1_code_school_path(@school), as: :json
     assert_response :unauthorized
   end
 end
 
 def cities_for(code_school)
-  code_school["locations"].map { |location| location["city"] }
+  code_school['locations'].map { |location| location['city'] }
 end

--- a/test/controllers/api/v1/email_list_recipients_controller_test.rb
+++ b/test/controllers/api/v1/email_list_recipients_controller_test.rb
@@ -6,10 +6,10 @@ class Api::V1::EmailListRecipientsControllerTest < ActionDispatch::IntegrationTe
 
     post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
 
-    assert JSON.parse(response.body) == { "email" => valid_email, "guest" => true }
+    assert JSON.parse(response.body) == { 'email' => valid_email, 'guest' => true }
   end
 
-  test ":create with a valid email address, responds with a status of 201 (created)" do
+  test ':create with a valid email address, responds with a status of 201 (created)' do
     stub_send_grid_job
 
     post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
@@ -17,19 +17,19 @@ class Api::V1::EmailListRecipientsControllerTest < ActionDispatch::IntegrationTe
     assert response.status == 201
   end
 
-  test ":create with a valid email address calls the AddGuestToSendGridJob" do
+  test ':create with a valid email address calls the AddGuestToSendGridJob' do
     AddGuestToSendGridJob.expects(:perform_later).with(valid_email)
 
     post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
   end
 
-  test ":create with a invalid email address renders an error message" do
+  test ':create with a invalid email address renders an error message' do
     post api_v1_email_list_recipients_path, params: { email: invalid_email }, as: :json
 
-    assert JSON.parse(response.body) == { "errors" => "Invalid email address: #{invalid_email}" }
+    assert JSON.parse(response.body) == { 'errors' => "Invalid email address: #{invalid_email}" }
   end
 
-  test ":create with an invalid email address does not call the AddGuestToSendGridJob" do
+  test ':create with an invalid email address does not call the AddGuestToSendGridJob' do
     0.times { AddGuestToSendGridJob.expects(:perform_later) }
 
     post api_v1_email_list_recipients_path, params: { email: invalid_email }, as: :json
@@ -41,9 +41,9 @@ def stub_send_grid_job
 end
 
 def valid_email
-  "john@gmail.com"
+  'john@gmail.com'
 end
 
 def invalid_email
-  "johngmail.com"
+  'johngmail.com'
 end

--- a/test/controllers/api/v1/locations_controller_test.rb
+++ b/test/controllers/api/v1/locations_controller_test.rb
@@ -6,7 +6,7 @@ class Api::V1::LocationsControllerTest < ActionDispatch::IntegrationTest
     @headers = authorization_headers(user)
   end
 
-  test "INVALID :create POST /api/v1/code_schools/:code_school_id/locations" do
+  test 'INVALID :create POST /api/v1/code_schools/:code_school_id/locations' do
     school = create(:code_school)
     params = {
       location: {
@@ -25,7 +25,7 @@ class Api::V1::LocationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
-  test "UNAUTHORIZED :create POST /api/v1/code_schools/:code_school_id/locations" do
+  test 'UNAUTHORIZED :create POST /api/v1/code_schools/:code_school_id/locations' do
     school = create(:code_school)
     params = {
       location: {
@@ -44,7 +44,7 @@ class Api::V1::LocationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
-  test ":create POST /api/v1/code_schools/:code_school_id/locations" do
+  test ':create POST /api/v1/code_schools/:code_school_id/locations' do
     school = create(:code_school)
     params = {
       location: {
@@ -63,7 +63,7 @@ class Api::V1::LocationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "INVALID :update PATCH /api/v1/code_schools/:code_school_id/locations/:id" do
+  test 'INVALID :update PATCH /api/v1/code_schools/:code_school_id/locations/:id' do
     school = create(:code_school)
     location = create(:location, code_school: school)
     params = {
@@ -83,7 +83,7 @@ class Api::V1::LocationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
-  test ":update PATCH /api/v1/code_schools/:code_school_id/locations/:id" do
+  test ':update PATCH /api/v1/code_schools/:code_school_id/locations/:id' do
     school = create(:code_school)
     location = create(:location, code_school: school)
     params = {
@@ -103,7 +103,7 @@ class Api::V1::LocationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "INVALID :destroy DELETE /api/v1/code_schools/:code_school_id/locations/:id" do
+  test 'INVALID :destroy DELETE /api/v1/code_schools/:code_school_id/locations/:id' do
     school = create(:code_school)
     location = create(:location, code_school: school)
 
@@ -112,7 +112,7 @@ class Api::V1::LocationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
-  test ":destroy DELETE /api/v1/code_schools/:code_school_id/locations/:id" do
+  test ':destroy DELETE /api/v1/code_schools/:code_school_id/locations/:id' do
     school = create(:code_school)
     location = create(:location, code_school: school)
 

--- a/test/controllers/api/v1/mentors_controller_test.rb
+++ b/test/controllers/api/v1/mentors_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Api::V1::MentorsControllerTest < ActionDispatch::IntegrationTest
 
-  test "users can get list of mentors" do
+  test 'users can get list of mentors' do
     skip
     user = create(:user)
     headers = authorization_headers(user)
@@ -11,7 +11,7 @@ class Api::V1::MentorsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2, response.parsed_body.count
   end
 
-  test "users can show a mentor" do
+  test 'users can show a mentor' do
     user = create(:user)
     headers = authorization_headers(user)
     mentor = create(:mentor)

--- a/test/controllers/api/v1/requests_controller_test.rb
+++ b/test/controllers/api/v1/requests_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Api::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
 
-  test "mentors can see all unclaimed requests" do
+  test 'mentors can see all unclaimed requests' do
     user = create(:mentor)
     headers = authorization_headers(user)
     request = create(:request)
@@ -20,7 +20,7 @@ class Api::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
     assert response.status, :forbidden
   end
 
-  test "create new requests for current user" do
+  test 'create new requests for current user' do
     user = create(:user)
     headers = authorization_headers(user)
     service = create(:service)
@@ -40,7 +40,7 @@ class Api::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_equal params[:request][:language], response.parsed_body['language']
   end
 
-  test "show individual request" do
+  test 'show individual request' do
     user = create(:mentor)
     headers = authorization_headers(user)
     request = create(:request)
@@ -50,7 +50,7 @@ class Api::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_equal request.id, response.parsed_body['id']
   end
 
-  test "show error message when unauthorized user tries to view individual request" do
+  test 'show error message when unauthorized user tries to view individual request' do
     user = create(:user)
     headers = authorization_headers(user)
     request = create(:request)
@@ -60,7 +60,7 @@ class Api::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
     assert response.status, :forbidden
   end
 
-  test "update individual request" do
+  test 'update individual request' do
     user = create(:user)
     mentor = create(:mentor)
     headers = authorization_headers(mentor)

--- a/test/controllers/api/v1/resources_controller_test.rb
+++ b/test/controllers/api/v1/resources_controller_test.rb
@@ -9,7 +9,7 @@ class Api::V1::ResourcesControllerTest < ActionDispatch::IntegrationTest
     @videos = create(:resource, name: 'Free videos')
   end
 
-  test ":index endpoint returns JSON list of Resources" do
+  test ':index endpoint returns JSON list of Resources' do
     get api_v1_resources_url, as: :json
 
     assert_equal response.status, 200
@@ -18,7 +18,7 @@ class Api::V1::ResourcesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test ":index endpoint returns correct tagged Resources when :tags param is passed" do
+  test ':index endpoint returns correct tagged Resources when :tags param is passed' do
     params = { tags: 'screencast, articles' }
     blog = create(:resource, name: 'Blog posts')
     blog.tag_list.add 'articles', parse: true
@@ -34,17 +34,17 @@ class Api::V1::ResourcesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test ":show endpoint returns JSON representation of the requested Resource" do
+  test ':show endpoint returns JSON representation of the requested Resource' do
     get api_v1_resource_url(@books.id), as: :json
 
     assert_equal response.status, 200
-    assert_equal @books.id, response.parsed_body["id"]
-    assert_equal @books.name, response.parsed_body["name"]
-    assert_equal @books.url, response.parsed_body["url"]
-    assert_equal @books.category, response.parsed_body["category"]
+    assert_equal @books.id, response.parsed_body['id']
+    assert_equal @books.name, response.parsed_body['name']
+    assert_equal @books.url, response.parsed_body['url']
+    assert_equal @books.category, response.parsed_body['category']
   end
 
-  test ":create endpoint creates a new Resource" do
+  test ':create endpoint creates a new Resource' do
     params = {
       name: 'Free videos site',
       url: 'free@videos.com',
@@ -59,7 +59,7 @@ class Api::V1::ResourcesControllerTest < ActionDispatch::IntegrationTest
     assert_equal({ 'resource' => videos.id, 'tags' => [] }, response.parsed_body)
   end
 
-  test ":create endpoint creates a new Resource with Tags" do
+  test ':create endpoint creates a new Resource with Tags' do
     params = {
       name: 'Free videos site',
       url: 'free@videos.com',
@@ -82,8 +82,8 @@ class Api::V1::ResourcesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test ":update endpoint updates an existing Resource" do
-    new_url = "more_free_videos@videos.com"
+  test ':update endpoint updates an existing Resource' do
+    new_url = 'more_free_videos@videos.com'
     params = {
       id: @videos.id,
       name: @videos.name,
@@ -111,7 +111,7 @@ class Api::V1::ResourcesControllerTest < ActionDispatch::IntegrationTest
     guides.tag_list.add old_tags, parse: true
     guides.save
 
-    assert_equal guides.tags.map(&:name).sort.join(", "), old_tags
+    assert_equal guides.tags.map(&:name).sort.join(', '), old_tags
 
     params = {
       id: guides.id,
@@ -134,7 +134,7 @@ class Api::V1::ResourcesControllerTest < ActionDispatch::IntegrationTest
     assert_equal guides.tags.map(&:name).join, new_tags
   end
 
-  test ":destroy endpoint destroys an existing Resource" do
+  test ':destroy endpoint destroys an existing Resource' do
     params = {
       id: @videos.id,
       name: @videos.name,

--- a/test/controllers/api/v1/services_controller_test.rb
+++ b/test/controllers/api/v1/services_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Api::V1::ServicesControllerTest < ActionDispatch::IntegrationTest
 
-  test "should get list of all services" do
+  test 'should get list of all services' do
     skip
     user = create(:user)
     headers = authorization_headers(user)

--- a/test/controllers/api/v1/slack_users_controller_test.rb
+++ b/test/controllers/api/v1/slack_users_controller_test.rb
@@ -11,7 +11,7 @@ class Api::V1::SlackUsersControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
 
     assert response.status == 200
-    assert body == { "message" => "You have access!" }
+    assert body == { 'message' => 'You have access!' }
   end
 
   test ':access returns a 401 with an incorrect token' do
@@ -24,7 +24,7 @@ class Api::V1::SlackUsersControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
 
     assert response.status == 401
-    assert body == { "errors" => ["Auth token is invalid"] }
+    assert body == { 'errors' => ['Auth token is invalid'] }
   end
 
   test ':access returns a 401 with an expired token' do
@@ -37,11 +37,11 @@ class Api::V1::SlackUsersControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
 
     assert response.status == 401
-    assert body == { "errors" => ["Auth token has expired"] }
+    assert body == { 'errors' => ['Auth token has expired'] }
   end
 
   test ':access returns a 401 with a malformed token' do
-    malformed_token = "a malformed token"
+    malformed_token = 'a malformed token'
 
     get access_api_v1_slack_users_url,
       headers: auth_headers(malformed_token),
@@ -50,7 +50,7 @@ class Api::V1::SlackUsersControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
 
     assert response.status == 401
-    assert body == { "errors" => ["Invalid auth token"] }
+    assert body == { 'errors' => ['Invalid auth token'] }
   end
 end
 

--- a/test/controllers/api/v1/social_users_controller_test.rb
+++ b/test/controllers/api/v1/social_users_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Api::V1::SocialUsersControllerTest < ActionDispatch::IntegrationTest
-  test "show returns /profile if the user is already registered" do
+  test 'show returns /profile if the user is already registered' do
     bob = create(:user, first_name: 'Bob', last_name: 'Belcher', email: 'bobs@burgers.com', zip: '62149', password: 'Archer' )
     params = { params: { email: 'bobs@burgers.com'} }
 
@@ -11,7 +11,7 @@ class Api::V1::SocialUsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal '/login', json['redirect_to']
   end
 
-  test "show returns /social_login if the user is not registered" do
+  test 'show returns /social_login if the user is not registered' do
     params = { params: { email: 'bobs@burgers.com'} }
 
     get api_v1_social_users_url(params), as: :json
@@ -20,7 +20,7 @@ class Api::V1::SocialUsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal '/social_login', json['redirect_to']
   end
 
-  test "create returns token, user and redirect path /profile when the user is already registered" do
+  test 'create returns token, user and redirect path /profile when the user is already registered' do
     james = create(:user, first_name: 'James', last_name: 'Kirk', email: 'kirk@starfleet.gov', zip: '13124', password: 'XOSpock' )
     params = { user: { first_name: 'James',last_name: 'Kirk',email: 'kirk@starfleet.gov',zip: '13124',password: 'XOSpock'} }
 
@@ -35,7 +35,7 @@ class Api::V1::SocialUsersControllerTest < ActionDispatch::IntegrationTest
     refute_nil json['token']
   end
 
-  test "create returns token, user and redirect path /social-login when the user is not registered" do
+  test 'create returns token, user and redirect path /social-login when the user is not registered' do
     params = { user: { first_name: 'Jean Luc',last_name: 'Picard',email: 'picard@tng.com',zip: '41153',password: 'Engage'} }
 
     post api_v1_social_users_url, params: params, as: :json

--- a/test/controllers/api/v1/tags_controller_test.rb
+++ b/test/controllers/api/v1/tags_controller_test.rb
@@ -4,15 +4,15 @@ class Api::V1::TagsControllerTest < ActionDispatch::IntegrationTest
   setup do
     resource = create :resource
 
-    resource.tag_list.add("books", "videos")
+    resource.tag_list.add('books', 'videos')
     resource.save
   end
 
-  test ":index endpoint returns JSON list of Tags" do
+  test ':index endpoint returns JSON list of Tags' do
     get api_v1_tags_url, as: :json
 
     assert_equal response.status, 200
-    ["books", "videos"].each do |tag_name|
+    ['books', 'videos'].each do |tag_name|
       assert_equal true, response.parsed_body.any? { |tag| tag['name'] == tag_name }
     end
   end

--- a/test/controllers/api/v1/team_members_controller_test.rb
+++ b/test/controllers/api/v1/team_members_controller_test.rb
@@ -6,21 +6,21 @@ class Api::V1::TeamMembersControllerTest < ActionDispatch::IntegrationTest
     @headers = authorization_headers(user)
   end
 
-  test ":index endpoint returns a JSON list of all TeamMembers" do
+  test ':index endpoint returns a JSON list of all TeamMembers' do
     john = create(:team_member)
-    alex = create(:team_member, name: "Alex Johnson")
+    alex = create(:team_member, name: 'Alex Johnson')
 
     get api_v1_team_members_url, as: :json
 
     [john.name, alex.name].each do |team_member|
-      assert_equal true, response.parsed_body.any? { |member| member["name"] == team_member }
+      assert_equal true, response.parsed_body.any? { |member| member['name'] == team_member }
     end
   end
 
-  test ":create endpoint creates a new TeamMember" do
+  test ':create endpoint creates a new TeamMember' do
     params = {
-      name: "Alex Johnson",
-      role: "Board Member",
+      name: 'Alex Johnson',
+      role: 'Board Member',
       group: TeamMember::BOARD_GROUP_NAME
     }
 
@@ -30,32 +30,32 @@ class Api::V1::TeamMembersControllerTest < ActionDispatch::IntegrationTest
     assert_equal({ 'team_member' => alex.id }, response.parsed_body)
   end
 
-  test ":create endpoint returns error for wrong group name" do
+  test ':create endpoint returns error for wrong group name' do
     params = {
-      name: "Alex Johnson",
-      role: "Board Member",
-      group: "intern"
+      name: 'Alex Johnson',
+      role: 'Board Member',
+      group: 'intern'
     }
 
     post api_v1_team_members_url, headers: @headers, params: params, as: :json
     assert_response :unprocessable_entity
   end
 
-  test ":create endpoint returns error for missing group field" do
+  test ':create endpoint returns error for missing group field' do
     params = {
-      name: "Alex Johnson",
-      role: "Board Member"
+      name: 'Alex Johnson',
+      role: 'Board Member'
     }
 
     post api_v1_team_members_url, headers: @headers, params: params, as: :json
     assert_response :unprocessable_entity
   end
 
-  test ":update endpoint updates an existing TeamMember" do
-    alex = create(:team_member, name: "Alex Johnson")
-    new_description = "Has worked for a lot of good companies"
-    new_image_src = "images/new_image.jpg"
-    new_role = "Legislative Affairs"
+  test ':update endpoint updates an existing TeamMember' do
+    alex = create(:team_member, name: 'Alex Johnson')
+    new_description = 'Has worked for a lot of good companies'
+    new_image_src = 'images/new_image.jpg'
+    new_role = 'Legislative Affairs'
     new_group = TeamMember::BOARD_GROUP_NAME
     params = {
       description: new_description,
@@ -76,8 +76,8 @@ class Api::V1::TeamMembersControllerTest < ActionDispatch::IntegrationTest
     assert_equal alex.role, new_role
   end
 
-  test ":destroy endpoint destroys an existing TeamMember" do
-    alex = create(:team_member, name: "Alex Johnson")
+  test ':destroy endpoint destroys an existing TeamMember' do
+    alex = create(:team_member, name: 'Alex Johnson')
     params = {
       id: alex.id,
       name: alex.name,

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
-  test ":index returns User.count" do
+  test ':index returns User.count' do
     2.times { create :user }
 
     get api_v1_users_url, as: :json
@@ -34,7 +34,7 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
       as: :json
 
     body = JSON.parse(response.body)
-    assert body["zip"] == ["can't be blank"]
+    assert body['zip'] == ["can't be blank"]
   end
 
   test '#create is successful with valid zip code' do
@@ -57,7 +57,7 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
     assert user_params[:zip], user.zip
   end
 
-  test ":by_location returns User.count of users located in the passed in location" do
+  test ':by_location returns User.count of users located in the passed in location' do
     tom = create :user
     sam = create :user
 

--- a/test/controllers/api/v1/votes_controller_test.rb
+++ b/test/controllers/api/v1/votes_controller_test.rb
@@ -7,7 +7,7 @@ class Api::V1::VotesControllerTest < ActionDispatch::IntegrationTest
     @resource = create :resource
   end
 
-  test ":create endpoint creates a new Vote" do
+  test ':create endpoint creates a new Vote' do
     params = {
       user_id: @user.id,
       resource_id: @resource.id
@@ -19,7 +19,7 @@ class Api::V1::VotesControllerTest < ActionDispatch::IntegrationTest
     assert_equal({ 'vote' => vote.id }, response.parsed_body)
   end
 
-  test "User cannot create more than one Vote for a given Resource" do
+  test 'User cannot create more than one Vote for a given Resource' do
     new_resource = create :resource
     create :vote, user: @user, resource: new_resource
     vote = create :vote, user: @user, resource: @resource
@@ -37,7 +37,7 @@ class Api::V1::VotesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2, @user.votes.count
   end
 
-  test ":destroy endpoint destroys an existing Vote" do
+  test ':destroy endpoint destroys an existing Vote' do
     vote = create :vote, user: @user, resource: @resource
 
     params = {

--- a/test/factories/events.rb
+++ b/test/factories/events.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
 
   factory :event do
-    name "MyEvent"
+    name 'MyEvent'
     description { Faker::Hacker.say_something_smart }
     url { Faker::Internet.url }
     start_date { Faker::Time.forward(30, :morning) }
@@ -9,7 +9,7 @@ FactoryGirl.define do
     address1 { Faker::Address.street_address }
     address2 { Faker::Address.street_address }
     city { Faker::Address.city }
-    source_type "Meetup"
+    source_type 'Meetup'
     source_id { Faker::Lorem.characters(7) }
     group { Faker::Lorem.characters(10) }
 

--- a/test/factories/git_hub_users.rb
+++ b/test/factories/git_hub_users.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :git_hub_user do
-    git_hub_login "oc coder"
+    git_hub_login 'oc coder'
     git_hub_id { Faker::Number.number(5).to_i }
   end
 end

--- a/test/factories/resources.rb
+++ b/test/factories/resources.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :resource do
-    name "Free Tech Books"
-    url "http://www.freetechbooks.com/"
-    category "Books"
-    language "Multiple"
+    name 'Free Tech Books'
+    url 'http://www.freetechbooks.com/'
+    category 'Books'
+    language 'Multiple'
     paid false
   end
 end

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :role do
-    title "standard_user"
+    title 'standard_user'
   end
 end

--- a/test/factories/scholarship_applications.rb
+++ b/test/factories/scholarship_applications.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :scholarship_application do
-    reason "MyText"
+    reason 'MyText'
     terms_accpeted false
-    references ""
-    references ""
+    references ''
+    references ''
   end
 end

--- a/test/factories/scholarships.rb
+++ b/test/factories/scholarships.rb
@@ -1,10 +1,10 @@
 FactoryGirl.define do
   factory :scholarship do
-    name "MyString"
-    description "MyText"
-    location "MyString"
-    terms "MyText"
-    open_time "2017-08-02 15:15:11"
-    close_time "2017-08-02 15:15:11"
+    name 'MyString'
+    description 'MyText'
+    location 'MyString'
+    terms 'MyText'
+    open_time '2017-08-02 15:15:11'
+    close_time '2017-08-02 15:15:11'
   end
 end

--- a/test/factories/team_members.rb
+++ b/test/factories/team_members.rb
@@ -1,10 +1,10 @@
 FactoryGirl.define do
   factory :team_member do
-    name "John Smith"
-    role "Board Advisor"
+    name 'John Smith'
+    role 'Board Advisor'
     group TeamMember::BOARD_GROUP_NAME
-    description "Long and wonderful history of employment"
-    image_src "images/john_smith.jpg"
+    description 'Long and wonderful history of employment'
+    image_src 'images/john_smith.jpg'
   end
 
   trait :board do

--- a/test/jobs/add_guest_to_send_grid_job_test.rb
+++ b/test/jobs/add_guest_to_send_grid_job_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class AddGuestToSendGridJobTest < ActiveJob::TestCase
-  test "it adds the guest to send grid" do
+  test 'it adds the guest to send grid' do
     guest = SendGridClient::Guest.user(valid_email)
 
     SendGridClient.any_instance.expects(:add_user).with(guest)
@@ -11,5 +11,5 @@ class AddGuestToSendGridJobTest < ActiveJob::TestCase
 end
 
 def valid_email
-  "john@gmail.com"
+  'john@gmail.com'
 end

--- a/test/lib/git_hub/authentication_test.rb
+++ b/test/lib/git_hub/authentication_test.rb
@@ -20,34 +20,34 @@ class GitHub::AuthenticationTest < ActiveSupport::TestCase
     @instance = GitHub::Authentication.new(@options)
   end
 
-  test "initialize constructs the expected variable" do
+  test 'initialize constructs the expected variable' do
     assert @instance.options == @options
     assert @instance.auth_level == GitHub::Authentication::O_AUTH_2_KEY_SECRET
   end
 
-  test "#set_options returns the passed in options when Rails.env.prod? is false" do
+  test '#set_options returns the passed in options when Rails.env.prod? is false' do
     assert @instance.set_options == @options
   end
 
-  test "#set_options merges the authenticated OAUTH_KEY options hash when Rails.env.prod? is true" do
+  test '#set_options merges the authenticated OAUTH_KEY options hash when Rails.env.prod? is true' do
     Rails.env.stubs(:prod?).returns(true)
 
     assert @instance.set_options == {
       :query =>
         {
-          :client_id => "some random id",
-          :client_secret => "some random key",
+          :client_id => 'some random id',
+          :client_secret => 'some random key',
           :per_page => 100
         },
       :headers =>
         {
-          "Accepts" => "application/vnd.github.v3+json",
-          "User-Agent" => "operationcode"
+          'Accepts' => 'application/vnd.github.v3+json',
+          'User-Agent' => 'operationcode'
         }
       }
   end
 
-  test "#set_options merges the authenticated OAUTH_TOKEN options hash when Rails.env.prod? is true" do
+  test '#set_options merges the authenticated OAUTH_TOKEN options hash when Rails.env.prod? is true' do
     GitHub::Settings.stubs(:authentication_level).returns(GitHub::Authentication::O_AUTH_2_TOKEN)
     Rails.env.stubs(:prod?).returns(true)
 
@@ -59,9 +59,9 @@ class GitHub::AuthenticationTest < ActiveSupport::TestCase
         },
       :headers =>
         {
-          "Accepts" => "application/vnd.github.v3+json",
-          "User-Agent" => "operationcode",
-          "Authorization" => "Bearer #{GitHub::Settings.o_auth_2_token}"
+          'Accepts' => 'application/vnd.github.v3+json',
+          'User-Agent' => 'operationcode',
+          'Authorization' => "Bearer #{GitHub::Settings.o_auth_2_token}"
         }
       }
   end

--- a/test/lib/git_hub/committer_test.rb
+++ b/test/lib/git_hub/committer_test.rb
@@ -27,7 +27,7 @@ class GitHub::CommitterTest < ActiveSupport::TestCase
     }
   end
 
-  test ".find_or_create_user! creates and returns non-existing GitHubUser" do
+  test '.find_or_create_user! creates and returns non-existing GitHubUser' do
     assert GitHubUser.count == 0
 
     user = GitHub::Committer.find_or_create_user! @user_attrs
@@ -35,14 +35,14 @@ class GitHub::CommitterTest < ActiveSupport::TestCase
     assert GitHubUser.first == user
   end
 
-  test ".find_or_create_user! returns the existing matched user" do
+  test '.find_or_create_user! returns the existing matched user' do
     user    = create :git_hub_user, git_hub_login: @user_attrs[:login]
     results = GitHub::Committer.find_or_create_user! @user_attrs.merge(id: user.git_hub_id)
 
     assert results == user
   end
 
-  test ".find_or_create_statistic! creates and returns non-existing GitHubStatistic" do
+  test '.find_or_create_statistic! creates and returns non-existing GitHubStatistic' do
     assert GitHubStatistic.count == 0
 
     stat = GitHub::Committer.find_or_create_statistic!(
@@ -54,7 +54,7 @@ class GitHub::CommitterTest < ActiveSupport::TestCase
     assert GitHubStatistic.first == stat
   end
 
-  test ".find_or_create_statistic! returns the existing matched user" do
+  test '.find_or_create_statistic! returns the existing matched user' do
     user = create :git_hub_user
     stat = create(
       :git_hub_statistic,

--- a/test/lib/git_hub/presenter_test.rb
+++ b/test/lib/git_hub/presenter_test.rb
@@ -21,7 +21,7 @@ class GitHub::PresenterTest < ActiveSupport::TestCase
     end
   end
 
-  test "#oc_totals returns totals across all repositories" do
+  test '#oc_totals returns totals across all repositories' do
     results = GitHub::Presenter.new({}).oc_totals
 
     assert results == {
@@ -35,7 +35,7 @@ class GitHub::PresenterTest < ActiveSupport::TestCase
     }
   end
 
-  test "#totals_by_repository returns totals grouped by repository" do
+  test '#totals_by_repository returns totals grouped by repository' do
     GitHubStatistic.stubs(:repositories).returns([@backend, @frontend])
 
     results = GitHub::Presenter.new({}).totals_by_repository
@@ -60,7 +60,7 @@ class GitHub::PresenterTest < ActiveSupport::TestCase
     }
   end
 
-  test "#totals_for_user returns totals for a passed in user, across all repositories" do
+  test '#totals_for_user returns totals for a passed in user, across all repositories' do
     jacks_results = GitHub::Presenter.new({ git_hub_login: @jack.git_hub_login }).totals_for_user
     johns_results = GitHub::Presenter.new({ git_hub_login: @john.git_hub_login }).totals_for_user
 
@@ -81,7 +81,7 @@ class GitHub::PresenterTest < ActiveSupport::TestCase
     }
   end
 
-  test "#oc_averages returns averages across all repositories" do
+  test '#oc_averages returns averages across all repositories' do
     results = GitHub::Presenter.new({}).oc_averages
 
     assert results == {
@@ -90,7 +90,7 @@ class GitHub::PresenterTest < ActiveSupport::TestCase
     }
   end
 
-  test "#totals_for_user_in_repository returns totals for a passed in user and repository" do
+  test '#totals_for_user_in_repository returns totals for a passed in user and repository' do
     john_backend = GitHub::Presenter.new({
       git_hub_login: @john.git_hub_login,
       repository: @backend
@@ -118,7 +118,7 @@ class GitHub::PresenterTest < ActiveSupport::TestCase
     }
   end
 
-  test "passing in optional start_date or end_date params scopes the query to those date ranges" do
+  test 'passing in optional start_date or end_date params scopes the query to those date ranges' do
     week_after = (@date + 1.week).to_s
     with_start = GitHub::Presenter.new({ start_date: week_after }).oc_totals
     with_end   = GitHub::Presenter.new({ end_date: week_after }).oc_totals

--- a/test/lib/meetup_test.rb
+++ b/test/lib/meetup_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 require_relative '../support/meetups/sample_api_responses'
 
 class MeetupTest < ActiveSupport::TestCase
-  test "some test" do
-    Meetup.stubs(:get).with("/pro/operationcode/groups", options).returns(group_endpoint_response)
+  test 'some test' do
+    Meetup.stubs(:get).with('/pro/operationcode/groups', options).returns(group_endpoint_response)
 
     parsed_response = Meetup.new.operationcode_data
 
@@ -11,28 +11,28 @@ class MeetupTest < ActiveSupport::TestCase
     assert_equal 21767819, parsed_response.first['id']
   end
 
-  test "group response code of 200 returns response" do
-    Meetup.stubs(:get).with("/pro/operationcode/groups", options).returns(group_endpoint_response)
+  test 'group response code of 200 returns response' do
+    Meetup.stubs(:get).with('/pro/operationcode/groups', options).returns(group_endpoint_response)
 
     assert_nothing_raised { Meetup.new.operationcode_data }
   end
 
-  test "group response code not equal to 200 raises error" do
-    Meetup.stubs(:get).with("/pro/operationcode/groups", options).returns(build_response(400))
+  test 'group response code not equal to 200 raises error' do
+    Meetup.stubs(:get).with('/pro/operationcode/groups', options).returns(build_response(400))
 
     assert_raises(Exception) { Meetup.new.operationcode_data }
   end
 
-  test "event response code of 200 returns response" do
-    url = "Operation-Code-Hampton-Roads"
+  test 'event response code of 200 returns response' do
+    url = 'Operation-Code-Hampton-Roads'
 
     Meetup.stubs(:get).with("/#{url}/events", options).returns(event_endpoint_response)
 
     assert_nothing_raised { Meetup.new.get_events_for url }
   end
 
-  test "event response code not equal to 200 raises error" do
-    url = "Operation-Code-Hampton-Roads"
+  test 'event response code not equal to 200 raises error' do
+    url = 'Operation-Code-Hampton-Roads'
 
     Meetup.stubs(:get).with("/#{url}/events", options).returns(build_response(400))
 
@@ -40,10 +40,10 @@ class MeetupTest < ActiveSupport::TestCase
   end
 
   #There are 4 events in the stub data, 1 with no venue
-  test "Meetup events with no venue are not included" do
-    url = "Operation-Code-Hampton-Roads"
+  test 'Meetup events with no venue are not included' do
+    url = 'Operation-Code-Hampton-Roads'
 
-    Meetup.stubs(:get).with("/pro/operationcode/groups", options).returns(group_endpoint_response)
+    Meetup.stubs(:get).with('/pro/operationcode/groups', options).returns(group_endpoint_response)
     Meetup.stubs(:get).with("/#{url}/events", options).returns(event_endpoint_response)
 
     events = Meetup.new.event_details_by_group
@@ -52,10 +52,10 @@ class MeetupTest < ActiveSupport::TestCase
   end
 
   #Event endpoint stubbed reponse has 3 good event records.
-  test "good data saves as new database record" do
-    url = "Operation-Code-Hampton-Roads"
+  test 'good data saves as new database record' do
+    url = 'Operation-Code-Hampton-Roads'
 
-    Meetup.stubs(:get).with("/pro/operationcode/groups", options).returns(group_endpoint_response)
+    Meetup.stubs(:get).with('/pro/operationcode/groups', options).returns(group_endpoint_response)
     Meetup.stubs(:get).with("/#{url}/events", options).returns(event_endpoint_response)
 
     assert_difference 'Event.count', 3 do
@@ -63,10 +63,10 @@ class MeetupTest < ActiveSupport::TestCase
     end
   end
 
-  test "duplicate data does not create new record" do
-    url = "Operation-Code-Hampton-Roads"
+  test 'duplicate data does not create new record' do
+    url = 'Operation-Code-Hampton-Roads'
 
-    Meetup.stubs(:get).with("/pro/operationcode/groups", options).returns(group_endpoint_response)
+    Meetup.stubs(:get).with('/pro/operationcode/groups', options).returns(group_endpoint_response)
     Meetup.stubs(:get).with("/#{url}/events", options).returns(event_endpoint_response)
 
     # create a Event record from first item in `event_endpoint_parsed_response`
@@ -80,10 +80,10 @@ class MeetupTest < ActiveSupport::TestCase
     assert_equal 3, Event.count
   end
 
-  test "updated data is updated in database" do
-    url = "Operation-Code-Hampton-Roads"
+  test 'updated data is updated in database' do
+    url = 'Operation-Code-Hampton-Roads'
 
-    Meetup.stubs(:get).with("/pro/operationcode/groups", options).returns(group_endpoint_response)
+    Meetup.stubs(:get).with('/pro/operationcode/groups', options).returns(group_endpoint_response)
     Meetup.stubs(:get).with("/#{url}/events", options).returns(event_endpoint_response)
 
     attributes = create_and_save_old_event

--- a/test/lib/send_grid_client/guest_test.rb
+++ b/test/lib/send_grid_client/guest_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 class SendGridClient::GuestTest < ActiveSupport::TestCase
-  test "#user creates a user-like Struct, to represent an OC guest" do
+  test '#user creates a user-like Struct, to represent an OC guest' do
     guest = SendGridClient::Guest.user(valid_email)
 
-    assert guest.to_s.include?("struct")
+    assert guest.to_s.include?('struct')
   end
 
   test "#user creates an :id method that defaults to 'guest-id'" do
@@ -13,7 +13,7 @@ class SendGridClient::GuestTest < ActiveSupport::TestCase
     assert guest.id == 'guest-id'
   end
 
-  test "#user creates an :email method that is set to the passed email address" do
+  test '#user creates an :email method that is set to the passed email address' do
     guest = SendGridClient::Guest.user(valid_email)
 
     assert guest.email == valid_email
@@ -23,14 +23,14 @@ class SendGridClient::GuestTest < ActiveSupport::TestCase
     guest = SendGridClient::Guest.user(valid_email)
 
     assert guest.attributes == {
-      "id" => "guest-id",
-      "email" => valid_email,
-      "first_name" => "",
-      "last_name" => ""
+      'id' => 'guest-id',
+      'email' => valid_email,
+      'first_name' => '',
+      'last_name' => ''
     }
   end
 end
 
 def valid_email
-  "john@gmail.com"
+  'john@gmail.com'
 end

--- a/test/lib/update_school_logos_test.rb
+++ b/test/lib/update_school_logos_test.rb
@@ -14,7 +14,7 @@ class UpdateSchoolLogosTest < ActiveSupport::TestCase
     assert_kind_of CodeSchool::ActiveRecord_Relation, schools
     schools.each do |school|
       logo = school.logo
-      assert_match "https://s3.amazonaws.com/operationcode-assets", logo
+      assert_match 'https://s3.amazonaws.com/operationcode-assets', logo
     end
   end
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -7,7 +7,7 @@ class UserMailerTest < ActiveSupport::TestCase
     new_user = create(:user)
     leader = create(:user)
     mail = UserMailer.new_user_in_leader_area(leader, new_user).deliver_now
-    assert_equal mail.subject, "A new user has joined within 50 miles of you"
+    assert_equal mail.subject, 'A new user has joined within 50 miles of you'
   end
 
   test 'renders the body' do

--- a/test/models/code_schools_test.rb
+++ b/test/models/code_schools_test.rb
@@ -5,15 +5,15 @@ class CodeSchoolTest < ActiveSupport::TestCase
     @code_school = build :code_school
   end
 
-  test "is_partner should be present and default to false" do
+  test 'is_partner should be present and default to false' do
     assert @code_school.is_partner == false
   end
 
-  test "rep_name should be present" do
+  test 'rep_name should be present' do
     assert @code_school.rep_name.present?
   end
 
-  test "rep_email should be present" do
+  test 'rep_email should be present' do
     assert @code_school.rep_email.present?
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -7,33 +7,33 @@ class EventTest < ActiveSupport::TestCase
     @event = build :event, :updated_today
   end
 
-  test "should be valid" do
+  test 'should be valid' do
   	#Current event as described in setup should be valid
   	assert @event.valid?
   end
 
-  test "name should be present" do
+  test 'name should be present' do
   	#Confirm empty event name is not valid
-  	@event.name = "    "
+  	@event.name = '    '
   	assert_not @event.valid?
   end
 
-  test "start_date should be present" do
-  	@event.start_date = "   "
+  test 'start_date should be present' do
+  	@event.start_date = '   '
   	assert_not @event.valid?
   end
 
-  test "address1 should be present" do
-  	@event.address1 = " "
+  test 'address1 should be present' do
+  	@event.address1 = ' '
   	assert_not @event.valid?
   end
 
-  test "city should be present" do
-  	@event.city = " "
+  test 'city should be present' do
+  	@event.city = ' '
   	assert_not @event.valid?
   end
 
-  test "website validation should accept valid websites" do
+  test 'website validation should accept valid websites' do
   	valid_websites=%w[http://www.somewebsite.com https://www.1234.com http://www.foobar.net]
     valid_websites.each do |valid_website|
       @event.url=valid_website
@@ -41,7 +41,7 @@ class EventTest < ActiveSupport::TestCase
     end
   end
 
-  test "website validation should reject invalid urls" do
+  test 'website validation should reject invalid urls' do
   	bad_websites = %w[w.badwebsite.com www,stillbad.com abc.fail.com wwww.foobar.com]
   	bad_websites.each do |bad_website|
       @event.url = bad_website

--- a/test/models/git_hub_statistic_test.rb
+++ b/test/models/git_hub_statistic_test.rb
@@ -22,7 +22,7 @@ class GitHubStatisticTest < ActiveSupport::TestCase
     assert_equal statistic.completed_on.to_s, GitHubStatistic.last_issue_completed_on
   end
 
-  test ".users_made_a_commit returns the unique count of users that have made a commit" do
+  test '.users_made_a_commit returns the unique count of users that have made a commit' do
     GitHubStatistic.delete_all
 
     stan, david, beth = create_users 3
@@ -35,7 +35,7 @@ class GitHubStatisticTest < ActiveSupport::TestCase
     assert_equal GitHubStatistic.users_made_a_commit, 2
   end
 
-  test ".users_closed_a_pr returns the unique count of users that have closed a pull request" do
+  test '.users_closed_a_pr returns the unique count of users that have closed a pull request' do
     GitHubStatistic.delete_all
 
     stan, david, beth = create_users 3
@@ -48,7 +48,7 @@ class GitHubStatisticTest < ActiveSupport::TestCase
     assert_equal GitHubStatistic.users_closed_a_pr, 2
   end
 
-  test ".repository_count returns the unique count of repositories we have statistics on" do
+  test '.repository_count returns the unique count of repositories we have statistics on' do
     GitHubStatistic.delete_all
 
     create :git_hub_statistic, repository: 'uno'
@@ -58,7 +58,7 @@ class GitHubStatisticTest < ActiveSupport::TestCase
     assert_equal GitHubStatistic.repository_count, 2
   end
 
-  test ".date_range returns records that have a :completed_on Date bewtween the passed in start and end dates" do
+  test '.date_range returns records that have a :completed_on Date bewtween the passed in start and end dates' do
     GitHubStatistic.delete_all
 
     twenty_10 = create :git_hub_statistic, completed_on: '2010-01-15'
@@ -73,7 +73,7 @@ class GitHubStatisticTest < ActiveSupport::TestCase
     assert_equal GitHubStatistic.date_range(start_date: '2014-01-10', end_date: '2014-01-19'), [twenty_14]
   end
 
-  test ".average_closed_prs_per_user returns a float value of the average number of pull requests closed, across all repositories, per user" do
+  test '.average_closed_prs_per_user returns a float value of the average number of pull requests closed, across all repositories, per user' do
     john = create :git_hub_user
     jack = create :git_hub_user
 
@@ -83,7 +83,7 @@ class GitHubStatisticTest < ActiveSupport::TestCase
     assert GitHubStatistic.average_closed_prs_per_user == 4.0
   end
 
-  test ".average_commits_prs_per_user returns a float value of the average number of commits, across all repositories, per user" do
+  test '.average_commits_prs_per_user returns a float value of the average number of commits, across all repositories, per user' do
     john = create :git_hub_user
     jack = create :git_hub_user
 

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class RequestTest < ActiveSupport::TestCase
-  test "the truth" do
+  test 'the truth' do
     request = create(:request)
     p request.requested_mentor
   end

--- a/test/models/resource_test.rb
+++ b/test/models/resource_test.rb
@@ -9,11 +9,11 @@ class ResourceTest < ActiveSupport::TestCase
     @books.save
   end
 
-  test ".with_tags returns all resources when no arguments are passed" do
+  test '.with_tags returns all resources when no arguments are passed' do
     assert_equal Resource.with_tags, [@books, @videos]
   end
 
-  test ".with_tags returns only relevant tagged resources when tagged arguments are passed" do
+  test '.with_tags returns only relevant tagged resources when tagged arguments are passed' do
     assert_equal Resource.with_tags('books'), [@books]
   end
 end

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -15,6 +15,6 @@ class RoleTest < ActiveSupport::TestCase
     duplicate_role.save
 
     refute duplicate_role.valid?
-    assert duplicate_role.errors.full_messages.include? "Title has already been taken"
+    assert duplicate_role.errors.full_messages.include? 'Title has already been taken'
   end
 end

--- a/test/models/team_member_test.rb
+++ b/test/models/team_member_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class TeamMemberTest < ActiveSupport::TestCase
-  test "member must have name, role and group" do
+  test 'member must have name, role and group' do
     team_member = build(:team_member)
     assert team_member.valid?
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -33,7 +33,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 'update_email@example.com', u.email
   end
 
-  test "role gets the Role with an id of user#role_id, if there is one" do
+  test 'role gets the Role with an id of user#role_id, if there is one' do
     user = create :user
     assert user.valid?
     assert user.role.nil?
@@ -194,18 +194,18 @@ class UserTest < ActiveSupport::TestCase
 
   test 'VALID_EMAIL regex ensures valid formatting' do
     # valid email formats
-    assert "john@gmail.com" =~ User::VALID_EMAIL
-    assert "j@example.com" =~ User::VALID_EMAIL
-    assert "jack@anything.io" =~ User::VALID_EMAIL
-    assert "jack@anything.org" =~ User::VALID_EMAIL
-    assert "jack@anything.net" =~ User::VALID_EMAIL
-    assert "jack@anything.whatever" =~ User::VALID_EMAIL
+    assert 'john@gmail.com' =~ User::VALID_EMAIL
+    assert 'j@example.com' =~ User::VALID_EMAIL
+    assert 'jack@anything.io' =~ User::VALID_EMAIL
+    assert 'jack@anything.org' =~ User::VALID_EMAIL
+    assert 'jack@anything.net' =~ User::VALID_EMAIL
+    assert 'jack@anything.whatever' =~ User::VALID_EMAIL
 
     # invalid email formats
-    refute "johngmail.com" =~ User::VALID_EMAIL
-    refute "john#gmail.com" =~ User::VALID_EMAIL
-    refute "john@gmail" =~ User::VALID_EMAIL
-    refute "@example.com" =~ User::VALID_EMAIL
+    refute 'johngmail.com' =~ User::VALID_EMAIL
+    refute 'john#gmail.com' =~ User::VALID_EMAIL
+    refute 'john@gmail' =~ User::VALID_EMAIL
+    refute '@example.com' =~ User::VALID_EMAIL
   end
 
   test '.community_leaders_nearby returns leaders within a radius from a lat/long' do

--- a/test/requests/git_hub/client_test.rb
+++ b/test/requests/git_hub/client_test.rb
@@ -26,11 +26,11 @@ class ClientTest < Minitest::Test
     assert response.headers['link'].present?
     assert response['items'].present?
     assert response.code.to_i == 200
-    assert pr['html_url'] == "https://github.com/OperationCode/operationcode/pull/753"
+    assert pr['html_url'] == 'https://github.com/OperationCode/operationcode/pull/753'
     assert pr['id'] == 240032714
     assert pr['number'] == @pr_number
-    assert pr['title'] == "Revert \"waffle.io Badge\""
-    assert pr['state'] == "closed"
+    assert pr['title'] == 'Revert "waffle.io Badge"'
+    assert pr['state'] == 'closed'
   end
 
   def test_successful_search_for_prs_for_single_page
@@ -52,11 +52,11 @@ class ClientTest < Minitest::Test
     assert response.headers['link'].present? == false
     assert response['items'].present?
     assert response.code.to_i == 200
-    assert pr['html_url'] == "https://github.com/OperationCode/operationcode_slashbot/pull/7"
+    assert pr['html_url'] == 'https://github.com/OperationCode/operationcode_slashbot/pull/7'
     assert pr['id'] == 221728378
     assert pr['number'] == 7
-    assert pr['title'] == "Add /android case"
-    assert pr['state'] == "closed"
+    assert pr['title'] == 'Add /android case'
+    assert pr['state'] == 'closed'
   end
 
   def test_successful_search_for_issues
@@ -83,7 +83,7 @@ class ClientTest < Minitest::Test
     assert issue['id'] == 250032036
     assert issue['number'] == 140
     assert issue['title'] == "Correct the spelling for 'distributions' in the contribution guide"
-    assert issue['state'] == "closed"
+    assert issue['state'] == 'closed'
   end
 
   def test_successful_single_pull_request
@@ -98,7 +98,7 @@ class ClientTest < Minitest::Test
     assert pr['additions'] == 0
     assert pr['deletions'] == 3
     assert pr['html_url'] == 'https://github.com/OperationCode/operationcode/pull/753'
-    assert pr['title'] == "Revert \"waffle.io Badge\""
+    assert pr['title'] == 'Revert "waffle.io Badge"'
     assert pr['merged_at'] == '2017-07-02T20:32:11Z'
 
     assert pr['user']['login'] == 'hollomancer'

--- a/test/requests/git_hub/page_compiler_test.rb
+++ b/test/requests/git_hub/page_compiler_test.rb
@@ -27,10 +27,10 @@ class GitHub::PageCompilerTest < Minitest::Test
     assert compiled_prs.size == 249
     assert compiled_prs.class == Array
     assert pr.class.to_s == 'Hash'
-    assert pr['html_url'] == "https://github.com/OperationCode/operationcode/pull/2"
+    assert pr['html_url'] == 'https://github.com/OperationCode/operationcode/pull/2'
     assert pr['id'] == 66372782
     assert pr['number'] == 2
-    assert pr['title'] == "Ignore OSX system files"
-    assert pr['state'] == "closed"
+    assert pr['title'] == 'Ignore OSX system files'
+    assert pr['state'] == 'closed'
   end
 end

--- a/test/requests/git_hub/pull_requests_test.rb
+++ b/test/requests/git_hub/pull_requests_test.rb
@@ -77,10 +77,10 @@ class PullRequestsTest < Minitest::Test
     assert @pr_instance.compiled_pull_requests.first[:repository] == 'operationcode_slashbot'
 
     assert @pr_instance.compiled_pull_requests.second[:source_type] == 'Commit'
-    assert @pr_instance.compiled_pull_requests.second[:title] == "Add /android case"
+    assert @pr_instance.compiled_pull_requests.second[:title] == 'Add /android case'
 
     assert @pr_instance.compiled_pull_requests.third[:source_type] == 'Commit'
-    assert @pr_instance.compiled_pull_requests.third[:title] == "Change environment variable for node"
+    assert @pr_instance.compiled_pull_requests.third[:title] == 'Change environment variable for node'
 
     assert @pr_instance.compiled_pull_requests.last[:source_type] == 'PullRequest'
     assert @pr_instance.compiled_pull_requests.last[:number] == 6

--- a/test/support/meetups/sample_api_responses.rb
+++ b/test/support/meetups/sample_api_responses.rb
@@ -26,133 +26,133 @@ end
 def event_endpoint_parsed_response
   [
     {
-      "created"=>1503597602000,
-      "id"=>"242801028",
-      "name"=>"Come Learn To Code!",
-      "status"=>"upcoming",
-      "time"=>1508454000000,
-      "updated"=>1503597602000,
-      "utc_offset"=>-14400000,
-      "waitlist_count"=>0,
-      "yes_rsvp_count"=>28,
-      "venue"=>
-       {"id"=>24628300,
-        "name"=>"1701",
-        "lat"=>36.844764709472656,
-        "lon"=>-75.97899627685547,
-        "repinned"=>false,
-        "address_1"=>"1701 Baltic Avenue",
-        "city"=>"Virginia Beach",
-        "country"=>"us",
-        "localized_country_name"=>"USA",
-        "zip"=>"",
-        "state"=>"VA"},
-      "group"=>
-       {"created"=>1483543375000,
-        "name"=>"Operation Code: Hampton Roads",
-        "id"=>21767819,
-        "join_mode"=>"open",
-        "lat"=>36.900001525878906,
-        "lon"=>-76.20999908447266,
-        "urlname"=>"Operation-Code-Hampton-Roads",
-        "who"=>"coders",
-        "localized_location"=>"Norfolk, VA",
-        "region"=>"en_US"},
-      "link"=>"https://www.meetup.com/Operation-Code-Hampton-Roads/events/242801028/",
-      "manual_attendance_count"=>0,
-      "description"=>
+      'created'=>1503597602000,
+      'id'=>'242801028',
+      'name'=>'Come Learn To Code!',
+      'status'=>'upcoming',
+      'time'=>1508454000000,
+      'updated'=>1503597602000,
+      'utc_offset'=>-14400000,
+      'waitlist_count'=>0,
+      'yes_rsvp_count'=>28,
+      'venue'=>
+       {'id'=>24628300,
+        'name'=>'1701',
+        'lat'=>36.844764709472656,
+        'lon'=>-75.97899627685547,
+        'repinned'=>false,
+        'address_1'=>'1701 Baltic Avenue',
+        'city'=>'Virginia Beach',
+        'country'=>'us',
+        'localized_country_name'=>'USA',
+        'zip'=>'',
+        'state'=>'VA'},
+      'group'=>
+       {'created'=>1483543375000,
+        'name'=>'Operation Code: Hampton Roads',
+        'id'=>21767819,
+        'join_mode'=>'open',
+        'lat'=>36.900001525878906,
+        'lon'=>-76.20999908447266,
+        'urlname'=>'Operation-Code-Hampton-Roads',
+        'who'=>'coders',
+        'localized_location'=>'Norfolk, VA',
+        'region'=>'en_US'},
+      'link'=>'https://www.meetup.com/Operation-Code-Hampton-Roads/events/242801028/',
+      'manual_attendance_count'=>0,
+      'description'=>
        "<p>Operation Code is an initiative to introduce veterans to the software development community. In this group, we will work together to design a website for aggregating veteran resources.</p> <p>No experience is necessary to join. In fact, we encourage those who want to learn how to code to join us! If you are a developer and would like to provide mentorship, we would greatly appreciate your participation, as well.</p> <p>In this meetup, we will discuss the progress that we've made and the next items on our list to complete. When the team is clear about the objectives, we will break into teams for pair programming and continue to build our website.</p> <p>Feel free to contact Larry Burris if you have any questions.</p> ",
-      "visibility"=>"public"
+      'visibility'=>'public'
     },
     {
-      "created"=>1506360598000,
-      "duration"=>7200000,
-      "id"=>"243654482",
-      "name"=>"Come Learn to Code!",
-      "status"=>"upcoming",
-      "time"=>1510875000000,
-      "updated"=>1506360640000,
-      "utc_offset"=>-18000000,
-      "waitlist_count"=>0,
-      "yes_rsvp_count"=>3,
-      "venue"=>
-       {"id"=>24975001,
-        "name"=>"ODU Innovation Center",
-        "lat"=>36.8532600402832,
-        "lon"=>-76.29104614257812,
-        "repinned"=>false,
-        "address_1"=>"501 Boush St",
-        "city"=>"Norfolk",
-        "country"=>"us",
-        "localized_country_name"=>"USA",
-        "zip"=>"23510",
-        "state"=>"VA"},
-      "group"=>
-       {"created"=>1483543375000,
-        "name"=>"Operation Code: Hampton Roads",
-        "id"=>21767819,
-        "join_mode"=>"open",
-        "lat"=>36.900001525878906,
-        "lon"=>-76.20999908447266,
-        "urlname"=>"Operation-Code-Hampton-Roads",
-        "who"=>"coders",
-        "localized_location"=>"Norfolk, VA",
-        "region"=>"en_US"},
-      "link"=>"https://www.meetup.com/Operation-Code-Hampton-Roads/events/243654482/",
-      "description"=>
+      'created'=>1506360598000,
+      'duration'=>7200000,
+      'id'=>'243654482',
+      'name'=>'Come Learn to Code!',
+      'status'=>'upcoming',
+      'time'=>1510875000000,
+      'updated'=>1506360640000,
+      'utc_offset'=>-18000000,
+      'waitlist_count'=>0,
+      'yes_rsvp_count'=>3,
+      'venue'=>
+       {'id'=>24975001,
+        'name'=>'ODU Innovation Center',
+        'lat'=>36.8532600402832,
+        'lon'=>-76.29104614257812,
+        'repinned'=>false,
+        'address_1'=>'501 Boush St',
+        'city'=>'Norfolk',
+        'country'=>'us',
+        'localized_country_name'=>'USA',
+        'zip'=>'23510',
+        'state'=>'VA'},
+      'group'=>
+       {'created'=>1483543375000,
+        'name'=>'Operation Code: Hampton Roads',
+        'id'=>21767819,
+        'join_mode'=>'open',
+        'lat'=>36.900001525878906,
+        'lon'=>-76.20999908447266,
+        'urlname'=>'Operation-Code-Hampton-Roads',
+        'who'=>'coders',
+        'localized_location'=>'Norfolk, VA',
+        'region'=>'en_US'},
+      'link'=>'https://www.meetup.com/Operation-Code-Hampton-Roads/events/243654482/',
+      'description'=>
        "<p>Operation Code is an initiative to introduce veterans to the software development community. In this group, we will work together to design a website for aggregating veteran resources.</p> <p>No experience is necessary to join. In fact, we encourage those who want to learn how to code to join us! If you are a developer and would like to provide mentorship, we would greatly appreciate your participation, as well.</p> <p>In this meetup, we will discuss the progress that we've made and the next items on our list to complete. When the team is clear about the objectives, we will break into teams for pair programming and continue to build our website.</p> <p>Feel free to contact Larry Burris if you have any questions.</p> ",
-      "visibility"=>"public"
+      'visibility'=>'public'
     },
     {
-      "created"=>1506361286000,
-      "duration"=>7200000,
-      "id"=>"243655170",
-      "name"=>"Come Learn To Code!",
-      "status"=>"upcoming",
-      "time"=>1513899000000,
-      "updated"=>1506361286000,
-      "utc_offset"=>-18000000,
-      "waitlist_count"=>0,
-      "yes_rsvp_count"=>2,
-      "venue"=>
-       {"id"=>24628300,
-        "name"=>"1701",
-        "lat"=>36.844764709472656,
-        "lon"=>-75.97899627685547,
-        "repinned"=>false,
-        "address_1"=>"1701 Baltic Avenue",
-        "city"=>"Virginia Beach",
-        "country"=>"us",
-        "localized_country_name"=>"USA",
-        "zip"=>"",
-        "state"=>"VA"},
-      "group"=>
-       {"created"=>1483543375000,
-        "name"=>"Operation Code: Hampton Roads",
-        "id"=>21767819,
-        "join_mode"=>"open",
-        "lat"=>36.900001525878906,
-        "lon"=>-76.20999908447266,
-        "urlname"=>"Operation-Code-Hampton-Roads",
-        "who"=>"coders",
-        "localized_location"=>"Norfolk, VA",
-        "region"=>"en_US"},
-      "link"=>"https://www.meetup.com/Operation-Code-Hampton-Roads/events/243655170/",
-      "description"=>
+      'created'=>1506361286000,
+      'duration'=>7200000,
+      'id'=>'243655170',
+      'name'=>'Come Learn To Code!',
+      'status'=>'upcoming',
+      'time'=>1513899000000,
+      'updated'=>1506361286000,
+      'utc_offset'=>-18000000,
+      'waitlist_count'=>0,
+      'yes_rsvp_count'=>2,
+      'venue'=>
+       {'id'=>24628300,
+        'name'=>'1701',
+        'lat'=>36.844764709472656,
+        'lon'=>-75.97899627685547,
+        'repinned'=>false,
+        'address_1'=>'1701 Baltic Avenue',
+        'city'=>'Virginia Beach',
+        'country'=>'us',
+        'localized_country_name'=>'USA',
+        'zip'=>'',
+        'state'=>'VA'},
+      'group'=>
+       {'created'=>1483543375000,
+        'name'=>'Operation Code: Hampton Roads',
+        'id'=>21767819,
+        'join_mode'=>'open',
+        'lat'=>36.900001525878906,
+        'lon'=>-76.20999908447266,
+        'urlname'=>'Operation-Code-Hampton-Roads',
+        'who'=>'coders',
+        'localized_location'=>'Norfolk, VA',
+        'region'=>'en_US'},
+      'link'=>'https://www.meetup.com/Operation-Code-Hampton-Roads/events/243655170/',
+      'description'=>
        "<p>Operation Code is an initiative to introduce veterans to the software development community. In this group, we will work together to design a website for aggregating veteran resources.</p> <p>No experience is necessary to join. In fact, we encourage those who want to learn how to code to join us! If you are a developer and would like to provide mentorship, we would greatly appreciate your participation, as well.</p> <p>In this meetup, we will discuss the progress that we've made and the next items on our list to complete. When the team is clear about the objectives, we will break into teams for pair programming and continue to build our website.</p> <p>Feel free to contact Larry Burris if you have any questions.</p> ",
-      "visibility"=>"public"
+      'visibility'=>'public'
     },
     {
-      "created"=>1506361383000,
-      "duration"=>7200000,
-      "id"=>"243655210",
-      "name"=>"Come learn to code!",
-      "status"=>"upcoming",
-      "time"=>1516318200000,
-      "updated"=>1506361383000,
-      "utc_offset"=>-18000000,
-      "waitlist_count"=>0,
-      "yes_rsvp_count"=>2,
+      'created'=>1506361383000,
+      'duration'=>7200000,
+      'id'=>'243655210',
+      'name'=>'Come learn to code!',
+      'status'=>'upcoming',
+      'time'=>1516318200000,
+      'updated'=>1506361383000,
+      'utc_offset'=>-18000000,
+      'waitlist_count'=>0,
+      'yes_rsvp_count'=>2,
       # "venue"=>
       #  {"id"=>24975001,
       #   "name"=>"ODU Innovation Center",
@@ -165,21 +165,21 @@ def event_endpoint_parsed_response
       #   "localized_country_name"=>"USA",
       #   "zip"=>"23510",
       #   "state"=>"VA"},
-      "group"=>
-       {"created"=>1483543375000,
-        "name"=>"Operation Code: Hampton Roads",
-        "id"=>21767819,
-        "join_mode"=>"open",
-        "lat"=>36.900001525878906,
-        "lon"=>-76.20999908447266,
-        "urlname"=>"Operation-Code-Hampton-Roads",
-        "who"=>"coders",
-        "localized_location"=>"Norfolk, VA",
-        "region"=>"en_US"},
-      "link"=>"https://www.meetup.com/Operation-Code-Hampton-Roads/events/243655210/",
-      "description"=>
+      'group'=>
+       {'created'=>1483543375000,
+        'name'=>'Operation Code: Hampton Roads',
+        'id'=>21767819,
+        'join_mode'=>'open',
+        'lat'=>36.900001525878906,
+        'lon'=>-76.20999908447266,
+        'urlname'=>'Operation-Code-Hampton-Roads',
+        'who'=>'coders',
+        'localized_location'=>'Norfolk, VA',
+        'region'=>'en_US'},
+      'link'=>'https://www.meetup.com/Operation-Code-Hampton-Roads/events/243655210/',
+      'description'=>
        "<p>Operation Code is an initiative to introduce veterans to the software development community. In this group, we will work together to design a website for aggregating veteran resources.</p> <p>No experience is necessary to join. In fact, we encourage those who want to learn how to code to join us! If you are a developer and would like to provide mentorship, we would greatly appreciate your participation, as well.</p> <p>In this meetup, we will discuss the progress that we've made and the next items on our list to complete. When the team is clear about the objectives, we will break into teams for pair programming and continue to build our website.</p> <p>Feel free to contact Larry Burris if you have any questions.</p> ",
-      "visibility"=>"public"
+      'visibility'=>'public'
     }
   ]
 end
@@ -192,14 +192,14 @@ def group_endpoint_parsed_response
   [
     {
       "id": 21767819,
-      "name": "Operation Code: Hampton Roads",
+      "name": 'Operation Code: Hampton Roads',
       "description": "<p>Operation Code is a nonprofit devoted to helping the military community learn software development, enter the tech industry, and code the future!</p> \n<p>We're looking to bring together aspiring developers of all levels and backgrounds, from learning-from-scratch to senior engineers, to help each other learn more about coding and building great things.</p>",
       "lat": 36.900001525878906,
       "lon": -76.20999908447266,
-      "city": "Norfolk",
-      "state": "VA",
-      "country": "USA",
-      "urlname": "Operation-Code-Hampton-Roads",
+      "city": 'Norfolk',
+      "state": 'VA',
+      "country": 'USA',
+      "urlname": 'Operation-Code-Hampton-Roads',
       "member_count": 341,
       "average_age": 31.79170036315918,
       "founded_date": 1483543375000,
@@ -214,71 +214,71 @@ def group_endpoint_parsed_response
       "topics": [
         {
           "id": 308,
-          "name": "Veterans",
-          "urlkey": "vets",
-          "lang": "en_US"
+          "name": 'Veterans',
+          "urlkey": 'vets',
+          "lang": 'en_US'
         },
         {
           "id": 563,
-          "name": "Open Source",
-          "urlkey": "opensource",
-          "lang": "en_US"
+          "name": 'Open Source',
+          "urlkey": 'opensource',
+          "lang": 'en_US'
         },
         {
           "id": 1863,
-          "name": "Military Families and Friends",
-          "urlkey": "mff",
-          "lang": "en_US"
+          "name": 'Military Families and Friends',
+          "urlkey": 'mff',
+          "lang": 'en_US'
         },
         {
           "id": 3833,
-          "name": "Software Development",
-          "urlkey": "softwaredev",
-          "lang": "en_US"
+          "name": 'Software Development',
+          "urlkey": 'softwaredev',
+          "lang": 'en_US'
         },
         {
           "id": 15582,
-          "name": "Web Development",
-          "urlkey": "web-development",
-          "lang": "en_US"
+          "name": 'Web Development',
+          "urlkey": 'web-development',
+          "lang": 'en_US'
         },
         {
           "id": 17836,
-          "name": "Support our military",
-          "urlkey": "support-our-military",
-          "lang": "en_US"
+          "name": 'Support our military',
+          "urlkey": 'support-our-military',
+          "lang": 'en_US'
         },
         {
           "id": 25610,
-          "name": "Veterans Service Organizations",
-          "urlkey": "veterans-service-organizations",
-          "lang": "en_US"
+          "name": 'Veterans Service Organizations',
+          "urlkey": 'veterans-service-organizations',
+          "lang": 'en_US'
         },
         {
           "id": 48471,
-          "name": "Computer programming",
-          "urlkey": "computer-programming",
-          "lang": "en_US"
+          "name": 'Computer programming',
+          "urlkey": 'computer-programming',
+          "lang": 'en_US'
         },
         {
           "id": 90286,
-          "name": "Social Coding",
-          "urlkey": "social-coding",
-          "lang": "en_US"
+          "name": 'Social Coding',
+          "urlkey": 'social-coding',
+          "lang": 'en_US'
         },
         {
           "id": 725122,
-          "name": "learn to code",
-          "urlkey": "learn-to-code",
-          "lang": "en_US"
+          "name": 'learn to code',
+          "urlkey": 'learn-to-code',
+          "lang": 'en_US'
         }
       ],
       "category": [
         {
           "id": 34,
-          "name": "Tech",
-          "shortname": "tech",
-          "sort_name": "Tech"
+          "name": 'Tech',
+          "shortname": 'tech',
+          "sort_name": 'Tech'
         }
       ],
       "gender_unknown": 0.0284000001847744,
@@ -287,37 +287,37 @@ def group_endpoint_parsed_response
       "gender_other": 0.0071000000461936,
       "organizers": [
         {
-          "name": "matt",
+          "name": 'matt',
           "member_id": 62995492,
-          "permission": "coorganizer"
+          "permission": 'coorganizer'
         },
         {
-          "name": "Larry Burris",
+          "name": 'Larry Burris',
           "member_id": 204630218,
-          "permission": "coorganizer"
+          "permission": 'coorganizer'
         },
         {
-          "name": "Conrad Hollomon",
+          "name": 'Conrad Hollomon',
           "member_id": 194532776,
-          "permission": "organizer"
+          "permission": 'organizer'
         }
       ],
-      "status": "Active",
+      "status": 'Active',
       "organizer_photo": {
         "id": 262534246,
-        "highres_link": "https://secure.meetupstatic.com/photos/member/8/5/c/6/highres_262534246.jpeg",
-        "photo_link": "https://secure.meetupstatic.com/photos/member/8/5/c/6/member_262534246.jpeg",
-        "thumb_link": "https://secure.meetupstatic.com/photos/member/8/5/c/6/thumb_262534246.jpeg",
-        "type": "member",
-        "base_url": "https://secure.meetupstatic.com"
+        "highres_link": 'https://secure.meetupstatic.com/photos/member/8/5/c/6/highres_262534246.jpeg',
+        "photo_link": 'https://secure.meetupstatic.com/photos/member/8/5/c/6/member_262534246.jpeg',
+        "thumb_link": 'https://secure.meetupstatic.com/photos/member/8/5/c/6/thumb_262534246.jpeg',
+        "type": 'member',
+        "base_url": 'https://secure.meetupstatic.com'
       },
       "group_photo": {
         "id": 457308404,
-        "highres_link": "https://secure.meetupstatic.com/photos/event/b/d/1/4/highres_457308404.jpeg",
-        "photo_link": "https://secure.meetupstatic.com/photos/event/b/d/1/4/600_457308404.jpeg",
-        "thumb_link": "https://secure.meetupstatic.com/photos/event/b/d/1/4/thumb_457308404.jpeg",
-        "type": "event",
-        "base_url": "https://secure.meetupstatic.com"
+        "highres_link": 'https://secure.meetupstatic.com/photos/event/b/d/1/4/highres_457308404.jpeg',
+        "photo_link": 'https://secure.meetupstatic.com/photos/event/b/d/1/4/600_457308404.jpeg',
+        "thumb_link": 'https://secure.meetupstatic.com/photos/event/b/d/1/4/thumb_457308404.jpeg',
+        "type": 'event',
+        "base_url": 'https://secure.meetupstatic.com'
       }
     }
   ].as_json

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,8 +31,8 @@ class ActiveSupport::TestCase
     return super if block.nil?
 
     cassette = [name, test_name].map do |str|
-      str.underscore.gsub(/[^A-Z]+/i, "_")
-    end.join("/")
+      str.underscore.gsub(/[^A-Z]+/i, '_')
+    end.join('/')
 
     super(test_name) do
       VCR.use_cassette(cassette) do


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->

We are temporarily excluding the `Style/StringLiterals` cop in our `.rubocop_todo.yml` file.  This cop needs to be enforced.

This PR:

- [ ] Remove the `Style/StringLiterals` style cop from the todo file
- [ ] Run the RuboCop autocorrect command (`rubocop -a --auto-correct`)
- [ ] Review all of the auto-corrections for accuracy

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #351 
