### PR TITLE
Adds new resources to ActiveAdmin for `Scholarship` and `ScholarshipApplication`

### DIFF
--- a/app/admin/scholarship.rb
+++ b/app/admin/scholarship.rb
@@ -1,0 +1,29 @@
+ActiveAdmin.register Scholarship do
+  permit_params :name, :description, :location, :terms, :open_time, :close_time
+  index do
+    selectable_column
+    id_column
+
+    column :name
+    column :description
+    column :location
+    column :terms
+    column :open_time
+    column :close_time
+
+    actions
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :description
+      f.input :location
+      f.input :terms
+      f.input :open_time
+      f.input :close_time
+    end
+
+    f.actions
+  end
+end

--- a/app/admin/scholarship.rb
+++ b/app/admin/scholarship.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Scholarship do
-  permit_params :name, :description, :location, :terms, :open_time, :close_time
+  permit_params :name, :description, :location, :terms, :open_time, :close_time, :created_at, :updated_at
   index do
     selectable_column
     id_column
@@ -10,6 +10,8 @@ ActiveAdmin.register Scholarship do
     column :terms
     column :open_time
     column :close_time
+    column :created_at
+    column :updated_at
 
     actions
   end

--- a/app/admin/scholarship_application.rb
+++ b/app/admin/scholarship_application.rb
@@ -8,8 +8,8 @@ ActiveAdmin.register ScholarshipApplication do
       scholarship_app.scholarship.name
     end
 
-    column 'User' do |user|
-      user.scholarship.name
+    column 'User' do |user_id|
+      user_id.scholarship.name
     end
 
     column :reason

--- a/app/admin/scholarship_application.rb
+++ b/app/admin/scholarship_application.rb
@@ -23,6 +23,7 @@ ActiveAdmin.register ScholarshipApplication do
   form do |f|
     f.inputs do
       f.input :scholarship_id, label: 'Scholarship', as: :select, collection: Scholarship.all.order(:name).map { |scholarship| [scholarship.name, scholarship.id]}, include_blank: false
+      f.input :user_id, label: 'User', as: :select, collection: User.all.order(:name).map { |user| [user.name, user.id]}, include_blank: false
       f.input :reason
       f.input :terms_accepted
     end

--- a/app/admin/scholarship_application.rb
+++ b/app/admin/scholarship_application.rb
@@ -22,13 +22,12 @@ ActiveAdmin.register ScholarshipApplication do
 
   form do |f|
     f.inputs do
-      f.input :scholarship_id, label: 'Scholarship', as: :select, collection: Scholarship.all.order(:name).map { |scholarship| [scholarship.name, scholarship.id]}, include_blank: false
-      f.input :user_id, label: 'User', as: :select, collection: User.all.order(:name).map { |user| [user.name, user.id]}, include_blank: false
+      f.input :scholarship_id, label: 'Scholarship', as: :select, collection: Scholarship.all.order(:name).map {|scholarship| [scholarship.name, scholarship.id]}, include_blank: false
+      f.input :user_id, label: 'User', as: :select, collection: User.all.order(:name).map {|user| [user.name, user.id]}, include_blank: false
       f.input :reason
       f.input :terms_accepted
     end
 
     f.actions
   end
-
 end

--- a/app/admin/scholarship_application.rb
+++ b/app/admin/scholarship_application.rb
@@ -1,0 +1,27 @@
+ActiveAdmin.register ScholarshipApplication do
+  permit_params :reason, :terms_accepted
+  index do
+    selectable_column
+    id_column
+
+    column 'Scholarship' do |scholarship_app|
+      scholarship_app.scholarship.name
+    end
+
+    column :reason
+    column :terms_accepted
+
+    actions
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :scholarship_id, label: 'Scholarship', as: :select, collection: Scholarship.all.order(:name).map { |scholarship| [scholarship.name, scholarship.id]}, include_blank: false
+      f.input :reason
+      f.input :terms_accepted
+    end
+
+    f.actions
+  end
+
+end

--- a/app/admin/scholarship_application.rb
+++ b/app/admin/scholarship_application.rb
@@ -9,13 +9,15 @@ ActiveAdmin.register ScholarshipApplication do
     end
 
     column 'User' do |user_id|
-      user_id.scholarship.name
+      user_id.user.email
     end
 
     column :reason
     column :terms_accepted
     column :scholarship_id
     column :user_id
+    column :created_at
+    column :updated_at
 
     actions
   end
@@ -23,7 +25,7 @@ ActiveAdmin.register ScholarshipApplication do
   form do |f|
     f.inputs do
       f.input :scholarship_id, label: 'Scholarship', as: :select, collection: Scholarship.all.order(:name).map { |scholarship| [scholarship.name, scholarship.id] }, include_blank: false
-      f.input :user_id, label: 'User', as: :select, collection: User.all.order(:name).map { |user| [user.name, user.id] }, include_blank: false
+      f.input :user_id, label: 'User', as: :select, collection: User.all.order(:email).map { |user| [user.email, user.id] }, include_blank: false
       f.input :reason
       f.input :terms_accepted
     end

--- a/app/admin/scholarship_application.rb
+++ b/app/admin/scholarship_application.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register ScholarshipApplication do
-  permit_params :reason, :terms_accepted
+  permit_params :reason, :terms_accepted, :scholarship_id, :user_id
   index do
     selectable_column
     id_column
@@ -8,8 +8,14 @@ ActiveAdmin.register ScholarshipApplication do
       scholarship_app.scholarship.name
     end
 
+    column 'User' do |user|
+      user.scholarship.name
+    end
+
     column :reason
     column :terms_accepted
+    column :scholarship_id
+    column :user_id
 
     actions
   end

--- a/app/admin/scholarship_application.rb
+++ b/app/admin/scholarship_application.rb
@@ -22,8 +22,8 @@ ActiveAdmin.register ScholarshipApplication do
 
   form do |f|
     f.inputs do
-      f.input :scholarship_id, label: 'Scholarship', as: :select, collection: Scholarship.all.order(:name).map {|scholarship| [scholarship.name, scholarship.id]}, include_blank: false
-      f.input :user_id, label: 'User', as: :select, collection: User.all.order(:name).map {|user| [user.name, user.id]}, include_blank: false
+      f.input :scholarship_id, label: 'Scholarship', as: :select, collection: Scholarship.all.order(:name).map { |scholarship| [scholarship.name, scholarship.id] }, include_blank: false
+      f.input :user_id, label: 'User', as: :select, collection: User.all.order(:name).map { |user| [user.name, user.id] }, include_blank: false
       f.input :reason
       f.input :terms_accepted
     end

--- a/app/admin/scholarship_application.rb
+++ b/app/admin/scholarship_application.rb
@@ -4,12 +4,12 @@ ActiveAdmin.register ScholarshipApplication do
     selectable_column
     id_column
 
-    column 'Scholarship' do |scholarship_app|
-      scholarship_app.scholarship.name
+    column 'Scholarship' do |scholarship_id|
+      scholarship_id.scholarship.name
     end
 
     column 'User' do |user_id|
-      user_id.user.email
+      user_id.user.name
     end
 
     column :reason

--- a/app/admin/scholarship_application.rb
+++ b/app/admin/scholarship_application.rb
@@ -25,7 +25,7 @@ ActiveAdmin.register ScholarshipApplication do
   form do |f|
     f.inputs do
       f.input :scholarship_id, label: 'Scholarship', as: :select, collection: Scholarship.all.order(:name).map { |scholarship| [scholarship.name, scholarship.id] }, include_blank: false
-      f.input :user_id, label: 'User', as: :select, collection: User.all.order(:email).map { |user| [user.email, user.id] }, include_blank: false
+      f.input :user_id, label: 'User', as: :select, collection: User.verified.order(:last_name).map { |user| [user.name, user.id] }, include_blank: false
       f.input :reason
       f.input :terms_accepted
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,8 @@ class Ability
       can :read, ActiveAdmin::Page, name: 'Dashboard', namespace_name: 'admin'
       can :read, CodeSchool
       can :read, Location
+      can :read, Scholarship
+      can :read, ScholarshipApplication
       can :read, Service
       can :read, TeamMember
       can :read, User
@@ -23,6 +25,8 @@ class Ability
       can :read, :all
       can :manage, CodeSchool
       can :manage, Location
+      can :manage, Scholarship
+      can :manage, ScholarshipApplication
       can :manage, Service
       can :manage, TeamMember
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,8 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 Request.destroy_all
+ScholarshipApplication.destroy_all
+Scholarship.destroy_all
 User.destroy_all
 Service.destroy_all
 TeamMember.destroy_all
@@ -16,7 +18,7 @@ Role.destroy_all
 FactoryGirl.create(:user)
 FactoryGirl.create(:user)
 rick = FactoryGirl.create(:mentor, first_name: 'Rick', last_name: 'Rein')
-nell = FactoryGirl.create(:mentor, first_name: 'Nell', last_name: 'Shamrell-Harrington')
+nell = FactoryGirl.create(:mentor, first_name: 'Nell', last_name: 'Shamrell-Harrington', verified: true)
 
 FactoryGirl.create(:request, language: 'Ruby', requested_mentor: rick)
 FactoryGirl.create(:request, language: 'Javascript')
@@ -30,7 +32,7 @@ FactoryGirl.create(:request, assigned_mentor: nell)
 end
 
 # Create team members
-SeedTeamMembers.seed_all 
+SeedTeamMembers.seed_all
 
 # Create Admin (development only)
 super_admin = Role.create!(title: 'super_admin')
@@ -41,11 +43,16 @@ AdminUser.create!(email: 'super_admin@example.com', password: 'password', passwo
 AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password', role_id: admin.id) if Rails.env.development?
 AdminUser.create!(email: 'board@example.com', password: 'password', password_confirmation: 'password', role_id: board.id) if Rails.env.development?
 
+scholarship = FactoryGirl.create(:scholarship)
+FactoryGirl.create(:scholarship_application, user: nell, scholarship: scholarship)
+
 users = User.count
 requests = Request.count
 services = Service.count
 team_members = TeamMember.count
 admin_users = AdminUser.count
+scholarship_count = Scholarship.count
+scholarship_app = ScholarshipApplication.count
 
 puts 'Seeding complete.  Created:'
 p "#{users} users"
@@ -53,3 +60,5 @@ p "#{requests} requests"
 p "#{services} services"
 p "#{team_members} team members"
 p "#{admin_users} admin users"
+p "#{scholarship_count} scholarships"
+p "#{scholarship_app} scholarship applications"

--- a/test/factories/scholarship_applications.rb
+++ b/test/factories/scholarship_applications.rb
@@ -1,8 +1,7 @@
 FactoryGirl.define do
   factory :scholarship_application do
     reason 'MyText'
-    terms_accpeted false
-    references ''
-    references ''
+    terms_accepted false
+    user
   end
 end

--- a/test/factories/scholarship_applications.rb
+++ b/test/factories/scholarship_applications.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     reason 'MyText'
     terms_accepted false
     association :user, factory: :user, verified: true
+    association :scholarship, factory: :scholarship
   end
 end

--- a/test/factories/scholarship_applications.rb
+++ b/test/factories/scholarship_applications.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :scholarship_application do
     reason 'MyText'
     terms_accepted false
-    user
+    association :user, factory: :user, verified: true
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
     bio { Faker::Company.bs }
     timezone 'EST'
     mentor false
-    verified false
+    verified true
     state { Faker::Address.state_abbr }
 
     factory :mentor do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
     bio { Faker::Company.bs }
     timezone 'EST'
     mentor false
-    verified true
+    verified false
     state { Faker::Address.state_abbr }
 
     factory :mentor do


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
  Gives admins the ability to conduct CRUD actions on the Scholarship and ScholarshipApplication 
  models. Currently this has to be done through prod's rails console.

  Adds a Resource for Scholarship to ActiveAdmin
  Adds a Resource for ScholarshipApplication to ActiveAdmin
  Updates ability.rb with the proper permissions 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #349 
