### PR TITLE
Adds is_partner to active admin codeschool

### DIFF
--- a/app/admin/code_school.rb
+++ b/app/admin/code_school.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register CodeSchool do
-  permit_params :name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only, :created_at, :updated_at, :notes, :mooc, :rep_name, :rep_email
+  permit_params :name, :url, :logo, :full_time, :hardware_included, :has_online, :online_only, :created_at, :updated_at, :notes, :mooc, :rep_name, :rep_email, :is_partner
 
   index do
     selectable_column
@@ -18,6 +18,7 @@ ActiveAdmin.register CodeSchool do
     column :mooc
     column :rep_name
     column :rep_email
+    column :is_partner
     column :created_at
     column :updated_at
 
@@ -37,6 +38,7 @@ ActiveAdmin.register CodeSchool do
       f.input :mooc
       f.input :rep_name
       f.input :rep_email
+      f.input :is_partner
     end
 
     f.actions


### PR DESCRIPTION
#Description of changes
This PR adds is_partner to app/admin/code_school.rb in the "permit_params", "index do end block", and the form block.

#Issue Resolved
is_partner should now show up in the admin dashboard for code schools.