### PR TITLE
Add military_status to user (fixes #373)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ Style/StringLiterals:
 Metrics/BlockLength:
   Exclude:
       - 'db/schema.rb'
+
+Metrics/ClassLength:
+  Exclude:
+      - 'test/models/user_test.rb'

--- a/apiary.apib
+++ b/apiary.apib
@@ -1796,7 +1796,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
         {
             errors: "Some error message"
         }
-## User | Update [/api/v1/users{?education_level,mentor,scholarship_info,employment_status,company_name,company_role,volunteer,branch_of_service,interests}]
+## User | Update [/api/v1/users{?education_level,mentor,scholarship_info,employment_status,company_name,company_role,volunteer,military_status,branch_of_service,interests}]
 
 + Parameters
 
@@ -1807,6 +1807,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
     + company_name (string, optional) - Users name of employer in the form on a string
     + company_role (string, optional) - Users role at company in the form of a string
     + volunteer (boolean, optional) - Is User wanting to volunteer in the form of a boolean
+    + military_status (string, optional) - Users military status in the form of a string
     + branch_of_service (string, optional) - Users branch of service in the form of a string
     + interests (string, optional) - User interests in the form of a string.
 
@@ -1827,6 +1828,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                 employment_status: "Employed",
                 company_name: "Comcast",
                 company_role: "Developer",
+                military_status: "spouse",
                 volunteer: "false",
                 branch_of_service: "Air Force",
                 interests: "Python, Python, Python, Python"
@@ -1847,7 +1849,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                 scholarship_info: "true",
                 employment_status: "Employed",
                 company_name: "Comcast",
-                company_role: "Developer",
+                company_role: "spouse",
                 volunteer: "false",
                 branch_of_service: "Air Force",
                 interests: "Python, Python, Python, Python"

--- a/apiary.apib
+++ b/apiary.apib
@@ -1849,7 +1849,8 @@ API endpoints that Operation Code's Rails backend makes available to its React f
                 scholarship_info: "true",
                 employment_status: "Employed",
                 company_name: "Comcast",
-                company_role: "spouse",
+                company_role: "Developer",
+                military_status: "spouse",
                 volunteer: "false",
                 branch_of_service: "Air Force",
                 interests: "Python, Python, Python, Python"

--- a/apiary.apib
+++ b/apiary.apib
@@ -1807,7 +1807,7 @@ API endpoints that Operation Code's Rails backend makes available to its React f
     + company_name (string, optional) - Users name of employer in the form on a string
     + company_role (string, optional) - Users role at company in the form of a string
     + volunteer (boolean, optional) - Is User wanting to volunteer in the form of a boolean
-    + military_status (string, optional) - Users military status in the form of a string
+    + military_status (string, optional) - Users military status, either current, veteran, spouse, or blank
     + branch_of_service (string, optional) - Users branch of service in the form of a string
     + interests (string, optional) - User interests in the form of a string.
 

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -114,7 +114,6 @@ ActiveAdmin.register User do
       f.input :linkedin
       f.input :employment_status
       f.input :education
-      f.input :military_status
       f.input :company_role
       f.input :company_name
       f.input :education_level

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -106,6 +106,7 @@ ActiveAdmin.register User do
       f.input :volunteer
       f.input :branch_of_service
       f.input :years_of_service
+      f.input :military_status, as: :select, collection: User::MILITARY_STATUSES.map { |status| [status, status].compact }.reject(&:empty?), include_blank: true
       f.input :pay_grade
       f.input :military_occupational_specialty
       f.input :github

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -6,7 +6,7 @@ ActiveAdmin.register User do
     :last_name, :timezone, :bio, :verified, :state, :address_1, :address_2, :city,
     :username, :volunteer, :branch_of_service, :years_of_service, :pay_grade,
     :military_occupational_specialty, :github, :twitter, :linkedin, :employment_status,
-    :education, :company_role, :company_name, :education_level, :interests
+    :education, :military_status, :company_role, :company_name, :education_level, :interests
 
   scope :all
   scope :mentors
@@ -74,6 +74,7 @@ ActiveAdmin.register User do
     column :linkedin
     column :employment_status
     column :education
+    column :military_status
     column :company_role
     column :company_name
     column :education_level
@@ -112,6 +113,7 @@ ActiveAdmin.register User do
       f.input :linkedin
       f.input :employment_status
       f.input :education
+      f.input :military_status
       f.input :company_role
       f.input :company_name
       f.input :education_level

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -74,6 +74,7 @@ module Api
           :linked_in,
           :employment_status,
           :education,
+          :military_status,
           :company_role,
           :company_name,
           :education_level,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,12 @@
 class User < ApplicationRecord
   LEADER = 'community leader'
 
+  # Validation of military_status
   CURRENT = 'current'
   VETERAN = 'veteran'
   SPOUSE = 'spouse'
   MILITARY_STATUSES = [CURRENT, VETERAN, SPOUSE, nil]
+  validates :size, inclusion: { in: %w(current veteran spouse),
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   VETERAN = 'veteran'
   SPOUSE = 'spouse'
   MILITARY_STATUSES = [CURRENT, VETERAN, SPOUSE, nil]
-  validates :size, inclusion: { in: %w(current veteran spouse),
+  validates :military_status, inclusion: { in: MILITARY_STATUSES }
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   CURRENT = 'current'
   VETERAN = 'veteran'
   SPOUSE = 'spouse'
-  MILITARY_STATUSES = [CURRENT, VETERAN, SPOUSE, nil]  
+  MILITARY_STATUSES = [CURRENT, VETERAN, SPOUSE, nil]
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,11 @@
 class User < ApplicationRecord
   LEADER = 'community leader'
 
+  CURRENT = 'current'
+  VETERAN = 'veteran'
+  SPOUSE = 'spouse'
+  MILITARY_STATUSES = [CURRENT, VETERAN, SPOUSE, nil]  
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/migrate/20180711212702_add_militarystatus_to_user.rb
+++ b/db/migrate/20180711212702_add_militarystatus_to_user.rb
@@ -1,0 +1,5 @@
+class AddMilitarystatusToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :military_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20180711212702) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,298 +10,300 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180430161218) do
+ActiveRecord::Schema.define(version: 20180711212702) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'active_admin_comments', force: :cascade do |t|
-    t.string 'namespace'
-    t.text 'body'
-    t.string 'resource_type'
-    t.integer 'resource_id'
-    t.string 'author_type'
-    t.integer 'author_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['author_type', 'author_id'], name: 'index_active_admin_comments_on_author_type_and_author_id', using: :btree
-    t.index ['namespace'], name: 'index_active_admin_comments_on_namespace', using: :btree
-    t.index ['resource_type', 'resource_id'], name: 'index_active_admin_comments_on_resource_type_and_resource_id', using: :btree
+  create_table "active_admin_comments", force: :cascade do |t|
+    t.string   "namespace"
+    t.text     "body"
+    t.string   "resource_type"
+    t.integer  "resource_id"
+    t.string   "author_type"
+    t.integer  "author_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
+    t.index ["namespace"], name: "index_active_admin_comments_on_namespace", using: :btree
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
   end
 
-  create_table 'admin_users', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.integer 'sign_in_count', default: 0, null: false
-    t.datetime 'current_sign_in_at'
-    t.datetime 'last_sign_in_at'
-    t.inet 'current_sign_in_ip'
-    t.inet 'last_sign_in_ip'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'role_id'
-    t.index ['email'], name: 'index_admin_users_on_email', unique: true, using: :btree
-    t.index ['reset_password_token'], name: 'index_admin_users_on_reset_password_token', unique: true, using: :btree
-    t.index ['role_id'], name: 'index_admin_users_on_role_id', using: :btree
+  create_table "admin_users", force: :cascade do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet     "current_sign_in_ip"
+    t.inet     "last_sign_in_ip"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.integer  "role_id"
+    t.index ["email"], name: "index_admin_users_on_email", unique: true, using: :btree
+    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["role_id"], name: "index_admin_users_on_role_id", using: :btree
   end
 
-  create_table 'code_schools', force: :cascade do |t|
-    t.string 'name'
-    t.string 'url'
-    t.string 'logo'
-    t.boolean 'full_time'
-    t.boolean 'hardware_included'
-    t.boolean 'has_online'
-    t.boolean 'online_only'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.text 'notes'
-    t.boolean 'mooc', default: false, null: false
-    t.boolean 'is_partner', default: false, null: false
-    t.string 'rep_name'
-    t.string 'rep_email'
+  create_table "code_schools", force: :cascade do |t|
+    t.string   "name"
+    t.string   "url"
+    t.string   "logo"
+    t.boolean  "full_time"
+    t.boolean  "hardware_included"
+    t.boolean  "has_online"
+    t.boolean  "online_only"
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.text     "notes"
+    t.boolean  "mooc",              default: false, null: false
+    t.boolean  "is_partner",        default: false, null: false
+    t.string   "rep_name"
+    t.string   "rep_email"
   end
 
-  create_table 'events', force: :cascade do |t|
-    t.string 'name'
-    t.text 'description'
-    t.string 'url'
-    t.datetime 'start_date'
-    t.datetime 'end_date'
-    t.string 'address1'
-    t.string 'address2'
-    t.string 'city'
-    t.string 'state'
-    t.string 'zip'
-    t.boolean 'scholarship_available'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'source_id'
-    t.string 'source_type'
-    t.datetime 'source_updated'
-    t.string 'group'
-    t.index ['source_id'], name: 'index_events_on_source_id', using: :btree
-    t.index ['source_type'], name: 'index_events_on_source_type', using: :btree
+  create_table "events", force: :cascade do |t|
+    t.string   "name"
+    t.text     "description"
+    t.string   "url"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.string   "address1"
+    t.string   "address2"
+    t.string   "city"
+    t.string   "state"
+    t.string   "zip"
+    t.boolean  "scholarship_available"
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+    t.string   "source_id"
+    t.string   "source_type"
+    t.datetime "source_updated"
+    t.string   "group"
+    t.index ["source_id"], name: "index_events_on_source_id", using: :btree
+    t.index ["source_type"], name: "index_events_on_source_type", using: :btree
   end
 
-  create_table 'git_hub_statistics', force: :cascade do |t|
-    t.integer 'git_hub_user_id'
-    t.string 'source_id'
-    t.string 'source_type'
-    t.string 'state'
-    t.integer 'additions'
-    t.integer 'deletions'
-    t.string 'repository'
-    t.string 'url'
-    t.string 'title'
-    t.string 'number'
-    t.date 'completed_on'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['git_hub_user_id'], name: 'index_git_hub_statistics_on_git_hub_user_id', using: :btree
+  create_table "git_hub_statistics", force: :cascade do |t|
+    t.integer  "git_hub_user_id"
+    t.string   "source_id"
+    t.string   "source_type"
+    t.string   "state"
+    t.integer  "additions"
+    t.integer  "deletions"
+    t.string   "repository"
+    t.string   "url"
+    t.string   "title"
+    t.string   "number"
+    t.date     "completed_on"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["git_hub_user_id"], name: "index_git_hub_statistics_on_git_hub_user_id", using: :btree
   end
 
-  create_table 'git_hub_users', force: :cascade do |t|
-    t.integer 'user_id'
-    t.string 'git_hub_login'
-    t.string 'avatar_url'
-    t.string 'api_url'
-    t.string 'html_url'
-    t.integer 'git_hub_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_git_hub_users_on_user_id', using: :btree
+  create_table "git_hub_users", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "git_hub_login"
+    t.string   "avatar_url"
+    t.string   "api_url"
+    t.string   "html_url"
+    t.integer  "git_hub_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["user_id"], name: "index_git_hub_users_on_user_id", using: :btree
   end
 
-  create_table 'locations', force: :cascade do |t|
-    t.boolean 'va_accepted'
-    t.string 'address1'
-    t.string 'address2'
-    t.string 'city'
-    t.string 'state'
-    t.integer 'zip'
-    t.integer 'code_school_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['code_school_id'], name: 'index_locations_on_code_school_id', using: :btree
+  create_table "locations", force: :cascade do |t|
+    t.boolean  "va_accepted"
+    t.string   "address1"
+    t.string   "address2"
+    t.string   "city"
+    t.string   "state"
+    t.integer  "zip"
+    t.integer  "code_school_id"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.index ["code_school_id"], name: "index_locations_on_code_school_id", using: :btree
   end
 
-  create_table 'requests', force: :cascade do |t|
-    t.integer 'service_id'
-    t.string 'language'
-    t.text 'details'
-    t.integer 'user_id'
-    t.integer 'assigned_mentor_id'
-    t.integer 'requested_mentor_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'status'
-    t.index ['assigned_mentor_id'], name: 'index_requests_on_assigned_mentor_id', using: :btree
-    t.index ['requested_mentor_id'], name: 'index_requests_on_requested_mentor_id', using: :btree
-    t.index ['service_id'], name: 'index_requests_on_service_id', using: :btree
-    t.index ['user_id'], name: 'index_requests_on_user_id', using: :btree
+  create_table "requests", force: :cascade do |t|
+    t.integer  "service_id"
+    t.string   "language"
+    t.text     "details"
+    t.integer  "user_id"
+    t.integer  "assigned_mentor_id"
+    t.integer  "requested_mentor_id"
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.string   "status"
+    t.index ["assigned_mentor_id"], name: "index_requests_on_assigned_mentor_id", using: :btree
+    t.index ["requested_mentor_id"], name: "index_requests_on_requested_mentor_id", using: :btree
+    t.index ["service_id"], name: "index_requests_on_service_id", using: :btree
+    t.index ["user_id"], name: "index_requests_on_user_id", using: :btree
   end
 
-  create_table 'resources', force: :cascade do |t|
-    t.string 'name'
-    t.string 'url'
-    t.string 'category'
-    t.string 'language'
-    t.boolean 'paid'
-    t.text 'notes'
-    t.integer 'votes_count', default: 0, null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "resources", force: :cascade do |t|
+    t.string   "name"
+    t.string   "url"
+    t.string   "category"
+    t.string   "language"
+    t.boolean  "paid"
+    t.text     "notes"
+    t.integer  "votes_count", default: 0, null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
-  create_table 'roles', force: :cascade do |t|
-    t.string 'title'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "roles", force: :cascade do |t|
+    t.string   "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'scholarship_applications', force: :cascade do |t|
-    t.text 'reason'
-    t.boolean 'terms_accepted'
-    t.integer 'user_id'
-    t.integer 'scholarship_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['scholarship_id'], name: 'index_scholarship_applications_on_scholarship_id', using: :btree
-    t.index ['user_id'], name: 'index_scholarship_applications_on_user_id', using: :btree
+  create_table "scholarship_applications", force: :cascade do |t|
+    t.text     "reason"
+    t.boolean  "terms_accepted"
+    t.integer  "user_id"
+    t.integer  "scholarship_id"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.index ["scholarship_id"], name: "index_scholarship_applications_on_scholarship_id", using: :btree
+    t.index ["user_id"], name: "index_scholarship_applications_on_user_id", using: :btree
   end
 
-  create_table 'scholarships', force: :cascade do |t|
-    t.string 'name'
-    t.text 'description'
-    t.string 'location'
-    t.text 'terms'
-    t.datetime 'open_time'
-    t.datetime 'close_time'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "scholarships", force: :cascade do |t|
+    t.string   "name"
+    t.text     "description"
+    t.string   "location"
+    t.text     "terms"
+    t.datetime "open_time"
+    t.datetime "close_time"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
-  create_table 'services', force: :cascade do |t|
-    t.string 'name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "services", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'slack_users', force: :cascade do |t|
-    t.string 'slack_id'
-    t.string 'slack_name'
-    t.string 'slack_real_name'
-    t.string 'slack_display_name'
-    t.string 'slack_email'
-    t.integer 'user_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['slack_email'], name: 'index_slack_users_on_slack_email', using: :btree
-    t.index ['slack_id'], name: 'index_slack_users_on_slack_id', using: :btree
-    t.index ['user_id'], name: 'index_slack_users_on_user_id', using: :btree
+  create_table "slack_users", force: :cascade do |t|
+    t.string   "slack_id"
+    t.string   "slack_name"
+    t.string   "slack_real_name"
+    t.string   "slack_display_name"
+    t.string   "slack_email"
+    t.integer  "user_id"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.index ["slack_email"], name: "index_slack_users_on_slack_email", using: :btree
+    t.index ["slack_id"], name: "index_slack_users_on_slack_id", using: :btree
+    t.index ["user_id"], name: "index_slack_users_on_user_id", using: :btree
   end
 
-  create_table 'taggings', force: :cascade do |t|
-    t.integer 'tag_id'
-    t.string 'taggable_type'
-    t.integer 'taggable_id'
-    t.string 'tagger_type'
-    t.integer 'tagger_id'
-    t.string 'context', limit: 128
-    t.datetime 'created_at'
-    t.index ['context'], name: 'index_taggings_on_context', using: :btree
-    t.index ['tag_id', 'taggable_id', 'taggable_type', 'context', 'tagger_id', 'tagger_type'], name: 'taggings_idx', unique: true, using: :btree
-    t.index ['tag_id'], name: 'index_taggings_on_tag_id', using: :btree
-    t.index ['taggable_id', 'taggable_type', 'context'], name: 'index_taggings_on_taggable_id_and_taggable_type_and_context', using: :btree
-    t.index ['taggable_id', 'taggable_type', 'tagger_id', 'context'], name: 'taggings_idy', using: :btree
-    t.index ['taggable_id'], name: 'index_taggings_on_taggable_id', using: :btree
-    t.index ['taggable_type'], name: 'index_taggings_on_taggable_type', using: :btree
-    t.index ['tagger_id', 'tagger_type'], name: 'index_taggings_on_tagger_id_and_tagger_type', using: :btree
-    t.index ['tagger_id'], name: 'index_taggings_on_tagger_id', using: :btree
+  create_table "taggings", force: :cascade do |t|
+    t.integer  "tag_id"
+    t.string   "taggable_type"
+    t.integer  "taggable_id"
+    t.string   "tagger_type"
+    t.integer  "tagger_id"
+    t.string   "context",       limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context", using: :btree
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+    t.index ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy", using: :btree
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id", using: :btree
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type", using: :btree
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type", using: :btree
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id", using: :btree
   end
 
-  create_table 'tags', force: :cascade do |t|
-    t.string 'name'
-    t.integer 'taggings_count', default: 0
-    t.index ['name'], name: 'index_tags_on_name', unique: true, using: :btree
+  create_table "tags", force: :cascade do |t|
+    t.string  "name"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true, using: :btree
   end
 
-  create_table 'team_members', force: :cascade do |t|
-    t.string 'name'
-    t.string 'role'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.text 'description'
-    t.string 'group'
-    t.string 'image_src'
-    t.string 'email', limit: 255
+  create_table "team_members", force: :cascade do |t|
+    t.string   "name"
+    t.string   "role"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.text     "description"
+    t.string   "group"
+    t.string   "image_src"
+    t.string   "email",       limit: 255
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email'
-    t.string 'zip'
-    t.float 'latitude'
-    t.float 'longitude'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.integer 'sign_in_count', default: 0, null: false
-    t.datetime 'current_sign_in_at'
-    t.datetime 'last_sign_in_at'
-    t.inet 'current_sign_in_ip'
-    t.inet 'last_sign_in_ip'
-    t.boolean 'mentor', default: false
-    t.string 'first_name'
-    t.string 'last_name'
-    t.string 'timezone'
-    t.text 'bio'
-    t.boolean 'verified', default: false, null: false
-    t.string 'state'
-    t.string 'address_1'
-    t.string 'address_2'
-    t.string 'city'
-    t.string 'username'
-    t.boolean 'volunteer', default: false
-    t.string 'branch_of_service'
-    t.float 'years_of_service'
-    t.string 'pay_grade'
-    t.string 'military_occupational_specialty'
-    t.string 'github'
-    t.string 'twitter'
-    t.string 'linkedin'
-    t.string 'employment_status'
-    t.string 'education'
-    t.string 'company_role'
-    t.string 'company_name'
-    t.string 'education_level'
-    t.string 'interests'
-    t.boolean 'scholarship_info', default: false
-    t.integer 'role_id'
-    t.index ['email'], name: 'index_users_on_email', unique: true, using: :btree
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true, using: :btree
-    t.index ['role_id'], name: 'index_users_on_role_id', using: :btree
+  create_table "users", force: :cascade do |t|
+    t.string   "email"
+    t.string   "zip"
+    t.float    "latitude"
+    t.float    "longitude"
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+    t.string   "encrypted_password",              default: "",    null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",                   default: 0,     null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet     "current_sign_in_ip"
+    t.inet     "last_sign_in_ip"
+    t.boolean  "mentor",                          default: false
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "timezone"
+    t.text     "bio"
+    t.boolean  "verified",                        default: false, null: false
+    t.string   "state"
+    t.string   "address_1"
+    t.string   "address_2"
+    t.string   "city"
+    t.string   "username"
+    t.boolean  "volunteer",                       default: false
+    t.string   "branch_of_service"
+    t.float    "years_of_service"
+    t.string   "pay_grade"
+    t.string   "military_occupational_specialty"
+    t.string   "github"
+    t.string   "twitter"
+    t.string   "linkedin"
+    t.string   "employment_status"
+    t.string   "education"
+    t.string   "company_role"
+    t.string   "company_name"
+    t.string   "education_level"
+    t.string   "interests"
+    t.boolean  "scholarship_info",                default: false
+    t.integer  "role_id"
+    t.string   "military_status"
+    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["role_id"], name: "index_users_on_role_id", using: :btree
   end
 
-  create_table 'votes', force: :cascade do |t|
-    t.integer 'user_id'
-    t.integer 'resource_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['resource_id'], name: 'index_votes_on_resource_id', using: :btree
-    t.index ['user_id'], name: 'index_votes_on_user_id', using: :btree
+  create_table "votes", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "resource_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["resource_id"], name: "index_votes_on_resource_id", using: :btree
+    t.index ["user_id"], name: "index_votes_on_user_id", using: :btree
   end
 
-  add_foreign_key 'git_hub_statistics', 'git_hub_users'
-  add_foreign_key 'locations', 'code_schools'
-  add_foreign_key 'requests', 'users'
-  add_foreign_key 'scholarship_applications', 'scholarships'
-  add_foreign_key 'scholarship_applications', 'users'
-  add_foreign_key 'votes', 'resources'
-  add_foreign_key 'votes', 'users'
+  add_foreign_key "git_hub_statistics", "git_hub_users"
+  add_foreign_key "locations", "code_schools"
+  add_foreign_key "requests", "users"
+  add_foreign_key "scholarship_applications", "scholarships"
+  add_foreign_key "scholarship_applications", "users"
+  add_foreign_key "votes", "resources"
+  add_foreign_key "votes", "users"
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class UserTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
+class UserTest < ActiveSupport::TestCase
   test 'actions are performed on user create' do
     user = build(:user, user_opts)
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -262,9 +262,10 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'military status accepts valid states' do
-    assert create(:user, military_status: 'spouse')
-    assert create(:user, military_status: 'veteran')
-    assert create(:user, military_status: 'current')
+    assert create(:user, military_status: User::CURRENT).valid?
+    assert create(:user, military_status: User::VETERAN).valid?
+    assert create(:user, military_status: User::SPOUSE).valid?
+    assert create(:user, military_status: nil).valid?
     refute User.new(military_status: 'spaghetti monster').valid?
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class UserTest < ActiveSupport::TestCase
+class UserTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
   test 'actions are performed on user create' do
     user = build(:user, user_opts)
 
@@ -259,5 +259,12 @@ class UserTest < ActiveSupport::TestCase
     assert_equal data[:email], userInfo[:email]
     assert_equal data[:zip], userInfo[:zip]
     assert_equal '/profile', redirect
+  end
+
+  test 'military status accepts valid states' do
+    assert create(:user, military_status: 'spouse')
+    assert create(:user, military_status: 'veteran')
+    assert create(:user, military_status: 'current')
+    refute create(:user, military_status: 'spaghetti monster')
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -265,6 +265,6 @@ class UserTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
     assert create(:user, military_status: 'spouse')
     assert create(:user, military_status: 'veteran')
     assert create(:user, military_status: 'current')
-    refute create(:user, military_status: 'spaghetti monster')
+    refute User.new(military_status: 'spaghetti monster').valid?
   end
 end


### PR DESCRIPTION
# Description of changes
Adds a column for `military_status`, which is currently not present on `users`. This will allow the information we request regarding a military spouse / active duty in signup flow to save to the DB.
# Issue Resolved
Part of fixing #373 (some frontend work needed)

_It's been a while for me. Please review._