### PR TITLE
Pass email value to Airtable as part of mentor request

### DIFF
--- a/app/controllers/api/v1/airtable/mentorships_controller.rb
+++ b/app/controllers/api/v1/airtable/mentorships_controller.rb
@@ -25,6 +25,7 @@ module Api
         def mentorship_params
           params.permit(
             :slack_user,
+            :email,
             :services,
             :skillsets,
             :additional_details,

--- a/app/lib/airtable/mentorship.rb
+++ b/app/lib/airtable/mentorship.rb
@@ -28,6 +28,7 @@ module Airtable
       request_body = {
         'fields' => {
           'Slack User' => body[:slack_user],
+          'Email' => body[:email],
           'Service' => format_for_posting(body[:services]),
           'Skillsets' => format_for_posting(body[:skillsets]),
           'Additional Details' => body[:additional_details],
@@ -51,7 +52,7 @@ module Airtable
       end
     end
 
-    # Converts a comman separated string into an array of strings
+    # Converts a comma separated string into an array of strings
     #
     # @param data_string [String] Comma separated strings of data
     # @return [Array] An array of stripped strings

--- a/test/controllers/api/v1/airtable/mentorships_controller_test.rb
+++ b/test/controllers/api/v1/airtable/mentorships_controller_test.rb
@@ -28,6 +28,7 @@ class Api::V1::Airtable::MentorshipsControllerTest < ActionDispatch::Integration
     VCR.use_cassette('airtable/mentorship/post_successful') do
       params = {
         slack_user: 'test_case_1',
+        email: 'test@example.com',
         services: 'rec3ZQMCQsKPKlE2C',
         skillsets: 'Java',
         additional_details: 'Some test description.',
@@ -51,6 +52,7 @@ class Api::V1::Airtable::MentorshipsControllerTest < ActionDispatch::Integration
     VCR.use_cassette('airtable/mentorship/post_multiple_successful') do
       params = {
         slack_user: 'test_case_1',
+        email: 'test@example.com',
         services: 'rec3ZQMCQsKPKlE2C',
         skillsets: 'Java, Study Help, Web (Frontend Development)',
         additional_details: 'Some test description.',


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Passes along the incoming `email` value for a Mentor Request from the React front-end to Airtable, so mentors have a reliable way of communicating with a mentee in case they are not yet on Slack.

This change is needed to assist with front-end issue https://github.com/OperationCode/operationcode_frontend/issues/971.  There are some proposed ideas to automatically populate the user's email field via PyBot and Slack integrations, but they are not yet implemented. cc @wimo7083 

Fuzzy hypothesis: Looks like passing along the email value to Airtable may also be needed to get the PyBot to populate the request to Slack ??
# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #377
