### PR TITLE
Issue384 Rubocop too strict

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,13 +5,17 @@ inherit_from: .rubocop_todo.yml
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiterals:
   Exclude:
-    - 'db/**/*'
+    - "db/**/*"
+
+#turn off end of line checks, git will fix this
+EndOfLine:
+  Enabled: false
 
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Exclude:
-      - 'db/schema.rb'
+    - "db/schema.rb"
 
 Metrics/ClassLength:
   Exclude:
-      - 'test/models/user_test.rb'
+    - "test/models/user_test.rb"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_from: .rubocop_todo.yml
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiterals:
   Exclude:
-    - "db/**/*"
+    - 'db/**/*'
 
 #turn off end of line checks, git will fix this
 EndOfLine:
@@ -14,8 +14,8 @@ EndOfLine:
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Exclude:
-    - "db/schema.rb"
+    - 'db/schema.rb'
 
 Metrics/ClassLength:
   Exclude:
-    - "test/models/user_test.rb"
+    - 'test/models/user_test.rb'


### PR DESCRIPTION
# Description of changes
Allows windows line endings to not get yelled at and has git standardize line endings. 


# Issue Resolved
Fixes #384 
