### PR TITLE
Raven testing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,13 +5,17 @@ inherit_from: .rubocop_todo.yml
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiterals:
   Exclude:
-    - 'db/**/*'
+    - "db/**/*"
+
+#turn off end of line checks, git will fix this
+EndOfLine:
+  Enabled: false
 
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Exclude:
-      - 'db/schema.rb'
+    - "db/schema.rb"
 
 Metrics/ClassLength:
   Exclude:
-      - 'test/models/user_test.rb'
+    - "test/models/user_test.rb"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_from: .rubocop_todo.yml
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiterals:
   Exclude:
-    - "db/**/*"
+    - 'db/**/*'
 
 #turn off end of line checks, git will fix this
 EndOfLine:
@@ -14,8 +14,8 @@ EndOfLine:
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Exclude:
-    - "db/schema.rb"
+    - 'db/schema.rb'
 
 Metrics/ClassLength:
   Exclude:
-    - "test/models/user_test.rb"
+    - 'test/models/user_test.rb'

--- a/app/controllers/api/v1/code_schools_controller.rb
+++ b/app/controllers/api/v1/code_schools_controller.rb
@@ -4,6 +4,13 @@ module Api
       before_action :authenticate_user!, only: [:create, :update, :destroy]
 
       def index
+        begin
+          Raven.capture do
+           Slack.invite('testing@testing.com')
+          end
+        rescue StandardError => msg
+          puts msg
+        end
         render json: CodeSchool.order(:name)
       end
 

--- a/app/lib/slack/client.rb
+++ b/app/lib/slack/client.rb
@@ -32,8 +32,13 @@ module Slack
           _attempts:   1
         }
       )
-      if !(body['ok'] || %w(already_in_team already_invited sent_recently).include?(body['error']))
-        raise InviteFailed.new(body.to_s)
+      
+      allowed_error_states = %w(already_in_team already_invited sent_recently)
+
+      if !(body['ok'] || allowed_error_states.include?(body['error']))
+        Raven.capture do
+          raise InviteFailed.new(body.to_s)
+        end
       end
 
       true


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
I tried working with raven-sentry to see if I could get an exception and have something happen locally. 

used this link and added code that would cause an exception: http://localhost:3000/api/v1/code_schools.json

If I did something like:
```
 Raven.capture do
           1 / 0 
 end
```
I would get a divide by zero exception. 
Ulitmately I wanted to try and trigger a invalid key, or timeout exception for the slack client but I am not familiar enough with the syntax. 

I was able to allow local debugging by getting a sentry.raven url I've started to use for pybot and attach it to `development.rb` 

in this format:

```
Raven.configure do |config|
  config.dsn = 'https://<key>:<secret>@sentry.io/<project>'
end
```

This would give me an error like this:


```
web_1                 | I, [2018-08-23T05:17:57.152192 #18]  INFO -- : {"method":"GET","path":"/api/v1/code_schools.json","format":"json","controller":"Api::V1::CodeSchoolsController","action":"index","status":500,"error":"NoMethodError: undefined method `invite' for Sla
ck:Module","duration":8.38,"view":0.0,"db":0.0,"@timestamp":"2018-08-23T05:17:57.151Z","@version":"1","message":"[500] GET /api/v1/code_schools.json (Api::V1::CodeSchoolsController#index)"}
web_1                 | I, [2018-08-23T05:17:57.181695 #18]  INFO -- : Sending event 069c3f0db1da45d9b896e06cde00f619 to Sentry
web_1                 | D, [2018-08-23T05:17:57.211969 #18] DEBUG -- : Raven HTTP Transport connecting to https://sentry.io
web_1                 | F, [2018-08-23T05:17:57.444784 #18] FATAL -- :
web_1                 | F, [2018-08-23T05:17:57.445056 #18] FATAL -- : NoMethodError (undefined method `invite' for Slack:Module):
web_1                 | F, [2018-08-23T05:17:57.445224 #18] FATAL -- :
web_1                 | F, [2018-08-23T05:17:57.445505 #18] FATAL -- : app/controllers/api/v1/code_schools_controller.rb:7:in `index'
```

While it states it sends the error to sentry, it doesn't appear in slack. If I follow the url to the sentry website I cannot login (don't have credentials). I'm going to try tomorrow and see how I can trigger this slack event and see other ways of hooking up the sentry for more information. 

I wonder if our settings for slack integration with sentry are related to no slack notifications. 

