### PR TITLE
wrap some factory attrs in blocks to make them lazy

### DIFF
--- a/test/factories/code_schools.rb
+++ b/test/factories/code_schools.rb
@@ -1,17 +1,17 @@
 FactoryGirl.define do
   factory :code_school do
-    name Faker::Company.name
-    url Faker::Internet.url
-    logo Faker::Internet.url
-    full_time Faker::Boolean.boolean
-    hardware_included Faker::Boolean.boolean
-    has_online Faker::Boolean.boolean
-    online_only Faker::Boolean.boolean
-    notes Faker::Lorem.paragraph
+    name { Faker::Company.name }
+    url { Faker::Internet.url }
+    logo { Faker::Internet.url }
+    full_time { Faker::Boolean.boolean }
+    hardware_included { Faker::Boolean.boolean }
+    has_online { Faker::Boolean.boolean }
+    online_only { Faker::Boolean.boolean }
+    notes { Faker::Lorem.paragraph }
     mooc false
     is_partner false
-    rep_name Faker::Name.name
-    rep_email Faker::Internet.email
+    rep_name { Faker::Name.name }
+    rep_email { Faker::Internet.email }
 
     factory :code_school_with_locations do
       transient do

--- a/test/factories/locations.rb
+++ b/test/factories/locations.rb
@@ -1,11 +1,11 @@
 FactoryGirl.define do
   factory :location do
     code_school { association(:code_school) || CodeSchool.last  }
-    va_accepted Faker::Boolean.boolean
-    address1 Faker::Address.street_address
-    address2 Faker::Address.street_address
-    city Faker::Address.city
-    state Faker::Address.state
-    zip Faker::Address.zip_code
+    va_accepted { Faker::Boolean.boolean }
+    address1 { Faker::Address.street_address }
+    address2 { Faker::Address.street_address }
+    city { Faker::Address.city }
+    state { Faker::Address.state }
+    zip { Faker::Address.zip_code }
   end
 end


### PR DESCRIPTION

# Description of changes

Laziness in a factory lets an attr be random. Without putting these in Ruby blocks, FactoryGirl will call Faker for an attribute once when a factory is first used and then use that value for every create() and
build() thereafter. 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
~Fixes #~

This is helpful in development for being able to generate a bunch of sample data in the database that looks different. It will also ensure that the records for the test suite are randomish to make sure tests aren't passing because of some underlying, but unintentional consistency.