### PR TITLE
refine the docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes_from:
       - bundle
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     depends_on:
       - operationcode-psql
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     image: redis:latest
 
   sidekiq:
-    build: .
+    image: operationcodebackend_web
     command: sidekiq -C config/sidekiq.yml.erb
     volumes:
       - .:/app


### PR DESCRIPTION
# Description of changes

* allow the sidekiq service to reuse the image built for the web service
* change the web service to bind to only the loopback interface (i.e. `localhost`) to avoid sharing your development backend with everyone in the coffee shop
* ~update the PG and Redis services to also bind their ports to host's loopback to allow devs to run the Ruby bits on the host OS while reusing the docker'd database and Redis store~ (removed from this PR because of port conflicts in Travis)

Each of these bullets were added in separate commits, so each change is reviewable in isolation from the others.
