### PR TITLE
changed makefile to use docker fresh start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ rmdi:
 rm-exited-containers: 
 	${DOCKER} ps -a -q -f status=exited | xargs ${DOCKER} rm -v 
 
+.PHONY: fresh-restart
+fresh-restart: minty-fresh setup test run
+
 .PHONY: console-sandbox
 	console-sandbox:
 	 docker-compose run ${RAILS_CONTAINER} rails console --sandbox

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,12 @@ DOCKER_COMPOSE := docker-compose
 .PHONY: all
 all: run 
 
-
-.PHONY: nuke 
+.PHONY:  nuke
 nuke: 
+	${DOCKER} system prune -a --volumes
+
+.PHONY: minty-fresh 
+minty-fresh: 
 	${DOCKER_COMPOSE} down --rmi all --volumes
 
 .PHONY: rmi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 RAILS_CONTAINER := web
 DOCKER := docker
+DOCKER_COMPOSE := docker-compose
 
 .PHONY: all
 all: run 
@@ -7,7 +8,7 @@ all: run
 
 .PHONY: nuke 
 nuke: 
-	${DOCKER} system prune -a --volumes
+	${DOCKER_COMPOSE} down --rmi all --volumes
 
 .PHONY: rmi
 rmi: 

--- a/docs/setup/docker_setup.md
+++ b/docs/setup/docker_setup.md
@@ -2,10 +2,11 @@
 
 ### Quick Reference
 1. Install Dependencies (git, make, docker)
+    i. Install [git](#git) 
 
-  a. Install [git](#git) 
-  b. Install [make](#make-for-windows-only)
-  c. Install [docker](#docker)
+    ii. Install [make](#make-for-windows-only)
+
+    iii. Install [docker](#docker)
 
 2. Retrieve [Codebase](#local-development-environment)
 3. Setup [Database](#database-setup)

--- a/docs/setup/docker_setup.md
+++ b/docs/setup/docker_setup.md
@@ -2,13 +2,15 @@
 
 ### Quick Reference
 1. Install Dependencies (git, make, docker)
+
   a. Install [git](#git) 
   b. Install [make](#make-for-windows-only)
   c. Install [docker](#docker)
-2. Retrieve Codebase [repo](#local-development-environment)
-3. Setup Database [database](#database-setup)
-4. Run Codebase [running](#running-operationcode-backend)
-5. Interact With Codebase [interact](#interact-with-backend)
+
+2. Retrieve [Codebase](#local-development-environment)
+3. Setup [Database](#database-setup)
+4. Run [Codebase](#running-operationcode-backend)
+5. Interact With [Codebase](#interact-with-backend)
 
 ## Install Dependencies
 

--- a/docs/setup/docker_setup.md
+++ b/docs/setup/docker_setup.md
@@ -69,3 +69,15 @@ make
 You can now visit http://localhost:3000 (or run `make open`) and you should see a Rails welcome message!
 
 In case you used the Docker Toolbox, you might have also installed VirtualBox, which creates its own virtual network adapters. In that case, the server might be running on that IP address and may not be reachable via localhost, 127.0.0.1 or even 0.0.0.0. So, you will need to use `netstat` on the command line to figure out the IP address on which the server is bound.
+
+#### Clean Up Docker:
+Once you are finished with any changes and they are commited you can clean up your environment to simulate a fresh start in production.
+
+Run `make minty-fresh` and you can clean up all images, and volumes to ensure a non-persistent state. Any time this action occurs or you run into an issue with any of the containers the recommend first course of action is 
+
+1. `make minty-fresh`
+2. `make setup`
+3. `make test`
+4. `make`
+
+This can be shortened to a make target: `make fresh-restart`

--- a/docs/setup/docker_setup.md
+++ b/docs/setup/docker_setup.md
@@ -1,5 +1,18 @@
 # Docker Setup
 
+### Quick Reference
+1. Install Dependencies (git, make, docker)
+  a. Install [git](#git) 
+  b. Install [make](#make-for-windows-only)
+  c. Install [docker](#docker)
+2. Retrieve Codebase [repo](#local-development-environment)
+3. Setup Database [database](#database-setup)
+4. Run Codebase [running](#running-operationcode-backend)
+5. Interact With Codebase [interact](#interact-with-backend)
+
+## Install Dependencies
+
+### Docker
 Docker is a container system. Click the appropriate link below to install Docker on your operating system.
 
 * [Mac](https://www.docker.com/docker-mac)
@@ -52,6 +65,7 @@ To run the OperationCode Backend simply type:
 make
 ```
 
+#### Interact With Backend:
 You can now visit http://localhost:3000 (or run `make open`) and you should see a Rails welcome message!
 
 In case you used the Docker Toolbox, you might have also installed VirtualBox, which creates its own virtual network adapters. In that case, the server might be running on that IP address and may not be reachable via localhost, 127.0.0.1 or even 0.0.0.0. So, you will need to use `netstat` on the command line to figure out the IP address on which the server is bound.

--- a/docs/setup/docker_setup.md
+++ b/docs/setup/docker_setup.md
@@ -2,6 +2,7 @@
 
 ### Quick Reference
 1. Install Dependencies (git, make, docker)
+    
     i. Install [git](#git) 
 
     ii. Install [make](#make-for-windows-only)


### PR DESCRIPTION
# Better way of using a fresh container start
<!-- What does this PR change and why -->
This will make a clean state and prevent errors but scope it to the actual project instead of system wide.

<details>
   #<summary>make minty-fresh following a make minty-fresh</summary>
<code>
C:\Users\wimo7\Desktop\back [make_nuke +1 ~0 -0 !]> make nuke
docker-compose down --rmi all --volumes
Removing network operationcodebackend_default
WARNING: Network operationcodebackend_default not found.
Removing image operationcodebackend_web
ERROR: Failed to remove image for service bundle: 404 Client Error: Not Found ("b'No such image: operationcodebackend_web:latest'")
Removing image postgres
ERROR: Failed to remove image for service operationcode-psql: 404 Client Error: Not Found ("b'No such image: postgres:latest'")
Removing image redis:latest
ERROR: Failed to remove image for service redis: 404 Client Error: Not Found ("b'No such image: redis:latest'")
Removing image operationcodebackend_web
ERROR: Failed to remove image for service web: 404 Client Error: Not Found ("b'No such image: operationcodebackend_web:latest'")
Removing image operationcodebackend_sidekiq
ERROR: Failed to remove image for service sidekiq: 404 Client Error: Not Found ("b'No such image: operationcodebackend_sidekiq:latest'")
</code>
</details>

<details>
   <summary>make minty-fresh following a make setup</summary>
<code>
C:\Users\wimo7\Desktop\back [make_nuke +1 ~1 -0 !]> make minty-fresh
docker-compose down --rmi all --volumes
Stopping operationcodebackend_redis_1              ... done
Stopping operationcodebackend_operationcode-psql_1 ... done
Removing operationcodebackend_web_run_2            ... done
Removing operationcodebackend_web_run_1            ... done
Removing operationcodebackend_bundle_1             ... done
Removing operationcodebackend_redis_1              ... done
Removing operationcodebackend_operationcode-psql_1 ... done
Removing network operationcodebackend_default
Removing image operationcodebackend_web
Removing image postgres
Removing image redis:latest
Removing image operationcodebackend_web
ERROR: Failed to remove image for service web: 404 Client Error: Not Found ("b'No such image: operationcodebackend_web:latest'")
Removing image operationcodebackend_sidekiq
</code>
</details>


<details>
   <summary>make nuke following a make minty-fresh</summary>
<code>
C:\Users\wimo7\Desktop\back [make_nuke +1 ~1 -0 !]> make minty-fresh
C:\Users\wimo7\Desktop\back [make_nuke +1 ~1 -0 !]> make nuke
docker system prune -a --volumes
WARNING! This will remove:
        - all stopped containers
        - all networks not used by at least one container
        - all volumes not used by at least one container
        - all images without at least one container associated to them
        - all build cache
Are you sure you want to continue? [y/N] y
Deleted Images:
untagged: ruby:2.3.3
untagged: ruby@sha256:fb643a7188c7567d5e32b47d674a32589df86bec769b5fef978951aa3efe994d
deleted: sha256:0e1db669d557d1137824b523e53ee2238eb6189aacb67b3e5581f09acdf126df
deleted: sha256:afcd02f7808c98ea261622f045ca34178e8a1d84a228ca3f3b1d20ac45f68eee
deleted: sha256:1094dfb5e0109b38addec79c3762dea68d5ebce00e1c83bf93475dc117edd7bc
deleted: sha256:744f388d5da66c3aa202094827b5f8267d999851cacbb893306591a4740e1f92
deleted: sha256:055bbe5afe4dd9f8444c609afded4e9ea1142c7a7aea2ea37cbd6dd02d8e7bf9
deleted: sha256:b8b6df6e52e797b462ec8424368959905d33693449f5c37a701075944d7cbc61
deleted: sha256:2ecb867048da2f6e2740814c177ca71c959ab2c91acaefbe827149302b20076f
deleted: sha256:763ac6a64f068afd061160ff77b7ab41f61aba49b554bfe39ca033fcbf4f2d3c
deleted: sha256:5d6cbe0dbcf9a675e86aa0fbedf7ed8756d557c7468d6a7c64bde7fa9e029636

Total reclaimed space: 733.9MB
</code>
</details>