### PR TITLE
Fix send grid job

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   #
   VALID_EMAIL = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
 
-  after_save :welcome_user
+  after_commit :welcome_user
   before_validation :strip_zip_code
   before_validation :geocode, if: ->(v) { v.zip.present? && v.zip_changed? }
   before_save :upcase_state

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   #
   VALID_EMAIL = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
 
-  after_create :welcome_user
+  after_save :welcome_user
   before_validation :strip_zip_code
   before_validation :geocode, if: ->(v) { v.zip.present? && v.zip_changed? }
   before_save :upcase_state


### PR DESCRIPTION
This fixes an error we were seeing in Sentry:

```
ActiveJob::DeserializationErrorSidekiq
errorError while trying to deserialize arguments: Couldn't find User with 'id'=5838
```

Turns out there is a common race condition when running a Sidekiq job right after a create or save - see [this extremely helpful article](https://www.justinweiss.com/articles/a-couple-callback-gotchas-and-a-rails-5-fix/) for more details.

I think that the current tests are sufficient to cover this behavior, but am willing to consider adding further testing if others think it is necessary.