### PR TITLE
modify makefile to fix issue with console-sandbox target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ fresh-restart: minty-fresh setup test run
 
 .PHONY: console-sandbox
 console-sandbox:
-	 docker-compose run ${RAILS_CONTAINER} rails console --sandbox
+	docker-compose run ${RAILS_CONTAINER} rails console --sandbox
 
 .PHONY: run
 run:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ rm-exited-containers:
 fresh-restart: minty-fresh setup test run
 
 .PHONY: console-sandbox
-	console-sandbox:
+console-sandbox:
 	 docker-compose run ${RAILS_CONTAINER} rails console --sandbox
 
 .PHONY: run


### PR DESCRIPTION
# Correct the makefile so the console-sandbox target works. 
<!-- What does this PR change and why -->
Currently:
```
C:\Users\wimo7\Desktop\back [make_console_fix +1 ~0 -0 !]> make console-sandbox
make: Nothing to be done for 'console-sandbox'.
```

There is a target for this though:
https://github.com/OperationCode/operationcode_backend/blob/b34ad45cc77a0c86d3918681e83066cf5d58a060/Makefile#L31

While the `.PHONY` is properly declared there is no valid target due to a tab:
![image](https://user-images.githubusercontent.com/10781353/45599980-8d418a00-b9b2-11e8-9b73-54046215b512.png)


# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes using a makefile target to run the console with the operation code docker instance. 
