### PR TITLE
schedule welcoming jobs after user has been saved to the database

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -13,6 +13,7 @@ module Api
         user = User.new(user_params)
 
         if user.save
+          user.welcome_user
           UserMailer.welcome(user).deliver unless user.invalid?
           sign_in(user)
           render json: { token: user.token }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,6 @@ class User < ApplicationRecord
   #
   VALID_EMAIL = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
 
-  after_create :welcome_user
   before_validation :strip_zip_code
   before_validation :geocode, if: ->(v) { v.zip.present? && v.zip_changed? }
   before_save :upcase_state

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.log_level = :warn
 end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -21,15 +21,19 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  def valid_user_params
+    {
+      email: 'test@example.com',
+      first_name: 'new first name',
+      password: 'Password',
+      zip: '97201'
+    }
+  end
+
   test '#create returns error with missing zip code' do
     post api_v1_users_url,
       params: {
-        user: {
-          email: 'test@example.com',
-          first_name: 'new first name',
-          password: 'Password',
-          zip: ''
-        }
+        user: valid_user_params.merge(zip: '')
       },
       as: :json
 
@@ -38,23 +42,23 @@ class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test '#create is successful with valid zip code' do
-    user_params = {
-      email: 'test@example.com',
-      first_name: 'new first name',
-      password: 'Password',
-      zip: '97201'
-    }
-
     post api_v1_users_url,
-      params: { user: user_params },
+      params: { user: valid_user_params },
       as: :json
 
     user = User.first
     assert_response :success
-    assert user_params[:email], user.email
-    assert user_params[:first_name], user.first_name
-    assert user_params[:password], user.password
-    assert user_params[:zip], user.zip
+    assert valid_user_params[:email], user.email
+    assert valid_user_params[:first_name], user.first_name
+    assert valid_user_params[:password], user.password
+    assert valid_user_params[:zip], user.zip
+  end
+
+  test '#create welcomes a new user' do
+    User.any_instance.expects(:welcome_user)
+    post api_v1_users_url,
+      params: { user: valid_user_params },
+      as: :json
   end
 
   test ':by_location returns User.count of users located in the passed in location' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -78,8 +78,8 @@ class UserTest < ActiveSupport::TestCase
     u = build(:user, latitude: nil, longitude: nil, zip: nil)
 
     u.update_attributes(zip: 'bad zip code')
-    assert_equal nil, u.latitude
-    assert_equal nil, u.longitude
+    assert_nil u.latitude
+    assert_nil u.longitude
   end
 
   test 'updates geocode after update' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,12 +1,15 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  test 'actions are performed on user create' do
-    user = build(:user, user_opts)
+  include ActiveJob::TestHelper
 
-    AddUserToSendGridJob.expects(:perform_later).with(user)
-
-    assert_difference('User.count') { user.save }
+  test 'welcoming a user adds them to SendGrid' do
+    user = create(:user, user_opts)
+    assert_enqueued_with(job: AddUserToSendGridJob,
+                         args: [user],
+                         queue: 'default') do
+      user.welcome_user
+    end
   end
 
   test 'must have a valid email' do


### PR DESCRIPTION
# Issue Resolved

This fixes a race condition between the web process creating the user record and a worker process picking up the job to use the user record to add them to SendGrid.

The race shows itself in an error from Sidekiq:

    ActiveJob::DeserializationError: Error while trying to deserialize
    arguments: Couldn't find User with 'id'=1234

# Description of changes

An alternative to #402 to fix the same AddToSendGridJob errors seen in production.

The `welcome_user()` method is the thing scheduling a job that is trying to find a user. Making the ActiveRecord lifecycle callbacks responsible for business processes can be painful to test and maintain. This change removes the welcoming of a user from the User model's callbacks and makes the controller action that creates users responsible for welcoming them. Asserting that the job is enqueued is then possible in the User model test without the double-enqueue that would occur before: once when the test user instance was created (saved and committed) and again when calling the `welcome_user()` method to test it.

Summary of changes:

* User's after_create callback to welcome_user is removed.
* User's tests are updated to only confirm that the job is enqueued when welcome_user() is called.
* UsersController now calls welcome_user after a user is successfully saved to the database which avoids the race condition between save and job execution.
* UsersController tests are updated to:
  * assert that User's welcome_user is called during create controller action
  * share a common set of valid user_params
  * dry the tests slightly by using the valid_user_params with a removal to test invalid user params
* BONUS
    * set test environment Rails output to WARN so that things like deprecation notices don't get lost in the noise of database logging
    * per a minitest dep notice: update nil checks to use `assert_nil thingie` instead of `assert_equal nil, thingie`

# Suggested Follow-on Work

- move the calls to `UserMailer.welcome(user).deliver` into the `User.welcome_user()` method

This email is sent from two places right now: [`api/v1/users_controller#create`](https://github.com/OperationCode/operationcode_backend/blob/b34ad45cc77a0c86d3918681e83066cf5d58a060/app/controllers/api/v1/users_controller.rb#L16) and [`models/user#fetch_social_user_and_redirect_path`](https://github.com/OperationCode/operationcode_backend/blob/master/app/models/user.rb#L192) called by `api/v1/social_users_controller#create`. The English in the mailer method implies that this email is part of welcoming a new user. It might be easier to maintain that welcoming process in one place and use it consistently for new users whether they are signing up with email+password or through social media.

- send mail in the background with `UserMailer.welcome(user).deliver_later`

ActionMailer and ActiveJob are pals. Mailer's `deliver_later` turns the sending of an email into a job so that the work of rendering and sending (and any errors that may occur) is Somebody Else's Problem from the perspective of a web request/response cycle. This will speed up the response time for sign-up and prevent email rendering or send errors from causing the web response to error. 

This would require updating the Sidekiq execution or config file—which appears to live outside this repo?—to include `mailers` in its list of queues to process.

- rename `User.welcome_user()` to `User.onboard()`

This method starts to encapsulate the business process of onboarding a new user which _includes_ welcoming but also other things (like adding to SendGrid, which doesn't appear to be a welcome)