### PR TITLE
remove validation of veteran status due to changed requirements

### DIFF
--- a/app/models/scholarship_application.rb
+++ b/app/models/scholarship_application.rb
@@ -1,5 +1,4 @@
 class ScholarshipApplication < ApplicationRecord
-  validate :user_is_verified
   validates :user_id, uniqueness: {scope: :scholarship_id}
 
   belongs_to :user
@@ -7,11 +6,4 @@ class ScholarshipApplication < ApplicationRecord
 
   delegate :name, to: :user, prefix: true
   delegate :email, to: :user, prefix: true
-  delegate :verified, to: :user, prefix: true
-
-  def user_is_verified
-    unless self.user_verified
-      errors.add(:verified, 'Only verified users may submit applications')
-    end
-  end
 end


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Removes the verification for users of id.me status. 

Removed the user_is_verified hook.
Removed the user_is_verified method
Removed the verified [delegate](https://apidock.com/rails/Module/delegate) - which is something I just learned about, but I still don't understand.


I left the FactoryGirl specifying a verified status, since it doesn't matter now. 

I haven't tested any verified routes before. This is a non-tested change, please don't merge unless you are able to test or assist me with testing this. 

I think I need to run both FE and BE locally, register a user and then test that this works locally. I'm going to try and get to that tomorrow. 







# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #408 
