### PR TITLE
add Sidekiq web UI to admin section; go max-Sidekiq with jobs

### DIFF
--- a/app/controllers/api/v1/email_list_recipients_controller.rb
+++ b/app/controllers/api/v1/email_list_recipients_controller.rb
@@ -4,7 +4,7 @@ module Api
       def create
         raise "Invalid email address: #{permitted_params[:email]}" unless valid_email?
 
-        AddGuestToSendGridJob.perform_later(permitted_params[:email])
+        AddGuestToSendGridJob.perform_async(permitted_params[:email])
 
         render json: { email: permitted_params[:email], guest: true }, status: :created
       rescue StandardError => e

--- a/app/jobs/add_guest_to_send_grid_job.rb
+++ b/app/jobs/add_guest_to_send_grid_job.rb
@@ -1,5 +1,5 @@
-class AddGuestToSendGridJob < ApplicationJob
-  queue_as :default
+class AddGuestToSendGridJob
+  include Sidekiq::Worker
 
   # Adds the passed guest to our Contact List in SendGrid.
   #

--- a/app/jobs/add_user_to_send_grid_job.rb
+++ b/app/jobs/add_user_to_send_grid_job.rb
@@ -1,7 +1,8 @@
 class AddUserToSendGridJob < ApplicationJob
-  queue_as :default
+  include Sidekiq::Worker
 
-  def perform(user)
+  def perform(user_id)
+    user = User.find(user_id)
     SendGridClient.new.add_user(user)
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,3 @@
-class ApplicationJob < ActiveJob::Base
+class ApplicationJob
+  include Sidekiq::Worker
 end

--- a/app/jobs/send_email_to_leaders_job.rb
+++ b/app/jobs/send_email_to_leaders_job.rb
@@ -1,5 +1,5 @@
-class SendEmailToLeadersJob < ActiveJob::Base
-  queue_as :default
+class SendEmailToLeadersJob < ApplicationJob
+  include Sidekiq::Worker
 
   def perform(_user_id)
     logger.debug 'Deprecated pathway, trying to determine what is placing this on queue.'

--- a/app/jobs/slack_jobs.rb
+++ b/app/jobs/slack_jobs.rb
@@ -1,8 +1,6 @@
 require 'slack/client'
 
-class SlackJobs < ActiveJob::Base
-  queue_as :default
-
+class SlackJobs < ApplicationJob
   private
 
   def slack_client

--- a/app/jobs/slack_jobs/inviter_job.rb
+++ b/app/jobs/slack_jobs/inviter_job.rb
@@ -1,5 +1,7 @@
 class SlackJobs
   class InviterJob < SlackJobs
+    include Sidekiq::Worker
+
     def perform(_email)
       logger.debug 'Deprecated pathway, trying to determine what is placing this on queue.'
     end

--- a/app/jobs/slack_jobs/notifier_job.rb
+++ b/app/jobs/slack_jobs/notifier_job.rb
@@ -1,6 +1,6 @@
 class SlackJobs
   class SlackNotifierJob < SlackJobs
-    queue_as :default
+    include Sidekiq::Worker
 
     def perform(_message, *)
       logger.debug 'Deprecated pathway, trying to determine what is placing this on queue.'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,7 +154,7 @@ class User < ApplicationRecord
   end
 
   def add_to_send_grid
-    AddUserToSendGridJob.perform_later(self)
+    AddUserToSendGridJob.perform_async(self.id)
   end
 
   def token

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -230,6 +230,14 @@ ActiveAdmin.setup do |config|
   #     end
   #   end
 
+  config.namespace :admin do |admin|
+    admin.build_menu :default do |menu|
+      menu.add label: 'Background Jobs',
+               url: '/admin/sidekiq',
+               html_options: { target: :blank }
+    end
+  end
+
   # == Download Links
   #
   # You can disable download links on resource listing pages,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,12 @@ Rails.application.routes.draw do
 
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
+
+  require 'sidekiq/web'
+  authenticate :admin_user, ->(u) { u.role.super_admin? } do
+    mount Sidekiq::Web => '/admin/sidekiq'
+  end
+
   devise_for :users
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/test/controllers/api/v1/email_list_recipients_controller_test.rb
+++ b/test/controllers/api/v1/email_list_recipients_controller_test.rb
@@ -1,26 +1,31 @@
 require 'test_helper'
 
 class Api::V1::EmailListRecipientsControllerTest < ActionDispatch::IntegrationTest
-  test ":create with a valid email address renders the guest's email address and guest: true" do
-    stub_send_grid_job
+  def setup
+    Sidekiq::Testing.fake!
+  end
 
+  def teardown
+    Sidekiq::Worker.clear_all
+  end
+
+  test ":create with a valid email address renders the guest's email address and guest: true" do
     post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
 
     assert JSON.parse(response.body) == { 'email' => valid_email, 'guest' => true }
   end
 
   test ':create with a valid email address, responds with a status of 201 (created)' do
-    stub_send_grid_job
-
     post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
 
     assert response.status == 201
   end
 
   test ':create with a valid email address calls the AddGuestToSendGridJob' do
-    AddGuestToSendGridJob.expects(:perform_later).with(valid_email)
-
     post api_v1_email_list_recipients_path, params: { email: valid_email }, as: :json
+
+    assert_equal 1, AddGuestToSendGridJob.jobs.length
+    assert_equal [valid_email], AddGuestToSendGridJob.jobs.first['args']
   end
 
   test ':create with a invalid email address renders an error message' do
@@ -30,14 +35,10 @@ class Api::V1::EmailListRecipientsControllerTest < ActionDispatch::IntegrationTe
   end
 
   test ':create with an invalid email address does not call the AddGuestToSendGridJob' do
-    0.times { AddGuestToSendGridJob.expects(:perform_later) }
+    0.times { AddGuestToSendGridJob.expects(:perform_async) }
 
     post api_v1_email_list_recipients_path, params: { email: invalid_email }, as: :json
   end
-end
-
-def stub_send_grid_job
-  AddGuestToSendGridJob.stubs(:perform_later).returns(true)
 end
 
 def valid_email

--- a/test/jobs/add_guest_to_send_grid_job_test.rb
+++ b/test/jobs/add_guest_to_send_grid_job_test.rb
@@ -1,12 +1,13 @@
 require 'test_helper'
 
-class AddGuestToSendGridJobTest < ActiveJob::TestCase
+class AddGuestToSendGridJobTest < ActiveSupport::TestCase
   test 'it adds the guest to send grid' do
+    job = AddGuestToSendGridJob.new
     guest = SendGridClient::Guest.user(valid_email)
 
     SendGridClient.any_instance.expects(:add_user).with(guest)
 
-    AddGuestToSendGridJob.perform_now(valid_email)
+    job.perform(valid_email)
   end
 end
 

--- a/test/jobs/add_user_to_send_grid_job_test.rb
+++ b/test/jobs/add_user_to_send_grid_job_test.rb
@@ -1,11 +1,12 @@
 require 'test_helper'
 
-class AddUserToSendGridJobTest < ActiveJob::TestCase
+class AddUserToSendGridJobTest < ActiveSupport::TestCase
   test 'it adds a user to send grid' do
-    user = FactoryGirl.build(:user)
+    job = AddUserToSendGridJob.new
+    user = FactoryGirl.create(:user)
 
     SendGridClient.any_instance.expects(:add_user).with(user)
 
-    AddUserToSendGridJob.perform_now(user)
+    job.perform(user.id)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'mocha/mini_test'
 require 'factory_girl'
+require 'sidekiq/testing'
 require 'vcr'
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
# Description of changes

This adds the Sidekiq web UI to the admin section under `/admin/sidekiq` for some better insight into the job queues. It also turns all the ActiveJob job classes into Sidekiq::Worker classes.

My recommendation is to commit to Sidekiq as the backend's background job processor. Some benefits of making backend's jobs full-fledged Sidekiq::Worker classes:

* more refined controls over when and how a job is executed
* easier test configuration to prevent the actual scheduling of jobs during a test run into a development environment
* increased visibility into the state of jobs through the Sidekiq administrative web UI

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #405 
