### PR TITLE
Removed open and closed scope from GitHubStatistic model

### DIFF
--- a/app/lib/git_hub/presenter.rb
+++ b/app/lib/git_hub/presenter.rb
@@ -10,7 +10,7 @@ module GitHub
       {
         total_repositories: base_query.repository_count,
         total_closed_pull_requests: base_query.pull_requests.count,
-        total_closed_issues: base_query.issues.closed.count,
+        total_closed_issues: base_query.issues.is_closed.count,
         total_commits: base_query.commits.count,
         total_users: base_query.users_made_a_commit,
         total_additions: base_query.sum(:additions),
@@ -22,7 +22,7 @@ module GitHub
       GitHubStatistic.repositories.each_with_object({}) do |repo, totals|
         totals[repo.to_sym] = {
           total_closed_pull_requests: base_query.for_repository(repo).pull_requests.count,
-          total_closed_issues: base_query.for_repository(repo).issues.closed.count,
+          total_closed_issues: base_query.for_repository(repo).issues.is_closed.count,
           total_commits: base_query.for_repository(repo).commits.count,
           total_users: base_query.for_repository(repo).users_made_a_commit,
           total_additions: base_query.for_repository(repo).sum(:additions),
@@ -38,7 +38,7 @@ module GitHub
 
       {
         total_closed_pull_requests: base_query.for_git_hub_user(user).pull_requests.count,
-        total_closed_issues: base_query.for_git_hub_user(user).issues.closed.count,
+        total_closed_issues: base_query.for_git_hub_user(user).issues.is_closed.count,
         total_commits: base_query.for_git_hub_user(user).commits.count,
         total_additions: base_query.for_git_hub_user(user).sum(:additions),
         total_deletions: base_query.for_git_hub_user(user).sum(:deletions),
@@ -61,7 +61,7 @@ module GitHub
 
       {
         total_closed_pull_requests: user_in_repository(user, repo).pull_requests.count,
-        total_closed_issues: user_in_repository(user, repo).issues.closed.count,
+        total_closed_issues: user_in_repository(user, repo).issues.is_closed.count,
         total_commits: user_in_repository(user, repo).commits.count,
         total_additions: user_in_repository(user, repo).sum(:additions),
         total_deletions: user_in_repository(user, repo).sum(:deletions),

--- a/app/models/git_hub_statistic.rb
+++ b/app/models/git_hub_statistic.rb
@@ -13,8 +13,8 @@ class GitHubStatistic < ApplicationRecord
   scope :pull_requests, -> { where(source_type: GitHubStatistic::PR) }
   scope :issues, -> { where(source_type: GitHubStatistic::ISSUE) }
   scope :commits, -> { where(source_type: GitHubStatistic::COMMIT) }
-  scope :closed, -> { where(state: 'closed') }
-  scope :open, -> { where(state: 'open') }
+  scope :is_closed, -> { where(state: 'closed') }
+  scope :is_open, -> { where(state: 'open') }
   scope :for_git_hub_user, -> git_hub_user { where(git_hub_user_id: git_hub_user.id) }
   scope :for_repository, -> repository { where(repository: repository) }
 
@@ -62,7 +62,7 @@ class GitHubStatistic < ApplicationRecord
   #
   def self.users_closed_a_pr
     self
-      .closed
+      .is_closed
       .pull_requests
       .pluck(:git_hub_user_id)
       .uniq
@@ -91,7 +91,7 @@ class GitHubStatistic < ApplicationRecord
   end
 
   def self.average_closed_prs_per_user
-    grouped_records = pull_requests.closed.group_by(&:git_hub_user_id)
+    grouped_records = pull_requests.is_closed.group_by(&:git_hub_user_id)
 
     return 0 unless grouped_records.present?
 
@@ -122,7 +122,7 @@ class GitHubStatistic < ApplicationRecord
 
   def self.last_closed_date
     self
-      .closed
+      .is_closed
       .order(completed_on: :desc)
       .first
       .try(:completed_on)


### PR DESCRIPTION
# Description of changes
I did this to prevent warning messages that would occur when creating scopes named open.

# Issue Resolved
No issue, just a quality of life improvement
