### PR TITLE
Test chatters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml
 
+# VSCode
+.vscode/*
+
 # Gradle:
 .idea/**/gradle.xml
 .idea/**/libraries

--- a/app/controllers/api/v1/resources_controller.rb
+++ b/app/controllers/api/v1/resources_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class ResourcesController < ApiController
       before_action :authenticate_user!, except: [:index, :show]
-      before_filter :set_resource, only: [:show, :update, :destroy]
+      before_action :set_resource, only: [:show, :update, :destroy]
 
       def index
         resources = Resource.with_tags params[:tags]

--- a/app/lib/git_hub/issues.rb
+++ b/app/lib/git_hub/issues.rb
@@ -9,13 +9,15 @@ module GitHub
       @date = GitHubStatistic.last_issue_completed_on
     end
 
-    def fetch_and_save!
+    def fetch_and_save!(print_results: true)
       get_issues.each do |issue|
         git_hub_user = GitHub::Committer.find_or_create_user! issue[:git_hub_user]
+        git_hub_issue_stat = GitHub::Committer.find_or_create_statistic! issue, issue[:source_type], git_hub_user.id
+
+        next unless print_results
         p 'git_hub_user:'
         p git_hub_user
 
-        git_hub_issue_stat = GitHub::Committer.find_or_create_statistic! issue, issue[:source_type], git_hub_user.id
         p 'git_hub_issue_stat:'
         p git_hub_issue_stat
       end

--- a/app/lib/git_hub/presenter.rb
+++ b/app/lib/git_hub/presenter.rb
@@ -10,7 +10,7 @@ module GitHub
       {
         total_repositories: base_query.repository_count,
         total_closed_pull_requests: base_query.pull_requests.count,
-        total_closed_issues: base_query.issues.closed.count,
+        total_closed_issues: base_query.issues.is_closed.count,
         total_commits: base_query.commits.count,
         total_users: base_query.users_made_a_commit,
         total_additions: base_query.sum(:additions),
@@ -22,7 +22,7 @@ module GitHub
       GitHubStatistic.repositories.each_with_object({}) do |repo, totals|
         totals[repo.to_sym] = {
           total_closed_pull_requests: base_query.for_repository(repo).pull_requests.count,
-          total_closed_issues: base_query.for_repository(repo).issues.closed.count,
+          total_closed_issues: base_query.for_repository(repo).issues.is_closed.count,
           total_commits: base_query.for_repository(repo).commits.count,
           total_users: base_query.for_repository(repo).users_made_a_commit,
           total_additions: base_query.for_repository(repo).sum(:additions),
@@ -38,7 +38,7 @@ module GitHub
 
       {
         total_closed_pull_requests: base_query.for_git_hub_user(user).pull_requests.count,
-        total_closed_issues: base_query.for_git_hub_user(user).issues.closed.count,
+        total_closed_issues: base_query.for_git_hub_user(user).issues.is_closed.count,
         total_commits: base_query.for_git_hub_user(user).commits.count,
         total_additions: base_query.for_git_hub_user(user).sum(:additions),
         total_deletions: base_query.for_git_hub_user(user).sum(:deletions),
@@ -61,7 +61,7 @@ module GitHub
 
       {
         total_closed_pull_requests: user_in_repository(user, repo).pull_requests.count,
-        total_closed_issues: user_in_repository(user, repo).issues.closed.count,
+        total_closed_issues: user_in_repository(user, repo).issues.is_closed.count,
         total_commits: user_in_repository(user, repo).commits.count,
         total_additions: user_in_repository(user, repo).sum(:additions),
         total_deletions: user_in_repository(user, repo).sum(:deletions),

--- a/app/lib/git_hub/pull_requests.rb
+++ b/app/lib/git_hub/pull_requests.rb
@@ -9,13 +9,15 @@ module GitHub
       @date = GitHubStatistic.last_pr_completed_on
     end
 
-    def fetch_and_save!
+    def fetch_and_save!(print_results: true)
       get_pull_requests.each do |pr|
         git_hub_user = GitHub::Committer.find_or_create_user! pr[:git_hub_user]
+        git_hub_pr_stat = GitHub::Committer.find_or_create_statistic! pr, pr[:source_type], git_hub_user.id
+
+        next unless print_results
         p 'git_hub_user:'
         p git_hub_user
 
-        git_hub_pr_stat = GitHub::Committer.find_or_create_statistic! pr, pr[:source_type], git_hub_user.id
         p 'git_hub_pr_stat:'
         p git_hub_pr_stat
       end

--- a/app/models/git_hub_statistic.rb
+++ b/app/models/git_hub_statistic.rb
@@ -13,8 +13,8 @@ class GitHubStatistic < ApplicationRecord
   scope :pull_requests, -> { where(source_type: GitHubStatistic::PR) }
   scope :issues, -> { where(source_type: GitHubStatistic::ISSUE) }
   scope :commits, -> { where(source_type: GitHubStatistic::COMMIT) }
-  scope :closed, -> { where(state: 'closed') }
-  scope :open, -> { where(state: 'open') }
+  scope :is_closed, -> { where(state: 'closed') }
+  scope :is_open, -> { where(state: 'open') }
   scope :for_git_hub_user, -> git_hub_user { where(git_hub_user_id: git_hub_user.id) }
   scope :for_repository, -> repository { where(repository: repository) }
 
@@ -62,7 +62,7 @@ class GitHubStatistic < ApplicationRecord
   #
   def self.users_closed_a_pr
     self
-      .closed
+      .is_closed
       .pull_requests
       .pluck(:git_hub_user_id)
       .uniq
@@ -91,7 +91,7 @@ class GitHubStatistic < ApplicationRecord
   end
 
   def self.average_closed_prs_per_user
-    grouped_records = pull_requests.closed.group_by(&:git_hub_user_id)
+    grouped_records = pull_requests.is_closed.group_by(&:git_hub_user_id)
 
     return 0 unless grouped_records.present?
 
@@ -122,7 +122,7 @@ class GitHubStatistic < ApplicationRecord
 
   def self.last_closed_date
     self
-      .closed
+      .is_closed
       .order(completed_on: :desc)
       .first
       .try(:completed_on)

--- a/lib/tasks/schools_from_yml.rake
+++ b/lib/tasks/schools_from_yml.rake
@@ -31,8 +31,8 @@ namespace :schools do
         Rails.logger.error message
       end
 
-      p "Created #{CodeSchool.count} code schools"
-      p "Created #{Location.count} locations"
+      # p "Created #{CodeSchool.count} code schools"
+      # p "Created #{Location.count} locations"
     end
   end
 end

--- a/lib/tasks/schools_from_yml.rake
+++ b/lib/tasks/schools_from_yml.rake
@@ -30,9 +30,6 @@ namespace :schools do
         puts message
         Rails.logger.error message
       end
-
-      # p "Created #{CodeSchool.count} code schools"
-      # p "Created #{Location.count} locations"
     end
   end
 end

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class RequestTest < ActiveSupport::TestCase
   test 'the truth' do
-    request = create(:request)
-    p request.requested_mentor
+    create(:request)
+    # p request.requested_mentor
   end
   
 end

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 class RequestTest < ActiveSupport::TestCase
   test 'the truth' do
     create(:request)
-    # p request.requested_mentor
   end
   
 end

--- a/test/requests/git_hub/issues_test.rb
+++ b/test/requests/git_hub/issues_test.rb
@@ -35,7 +35,7 @@ class IssuesTest < Minitest::Test
   end
 
   def test_fetch_and_save
-    @issue_instance.fetch_and_save!
+    @issue_instance.fetch_and_save!(print_results: false)
 
     assert GitHubStatistic.for_repository(@backend).count == 28
     assert GitHubStatistic.for_repository(@backend).issues.count == 28

--- a/test/requests/git_hub/pull_requests_test.rb
+++ b/test/requests/git_hub/pull_requests_test.rb
@@ -51,7 +51,7 @@ class PullRequestsTest < Minitest::Test
   end
 
   def test_fetch_and_save
-    @pr_instance.fetch_and_save!
+    @pr_instance.fetch_and_save!(print_results: false)
 
     assert GitHubStatistic.for_repository(@slash).count == 4
     assert GitHubStatistic.for_repository(@slash).pull_requests.count == 2


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
1. Reduce verbosity for tests
This reduces the amount of chatter seen while running unit tests. In cases where the rake file printed out debug information this adds an override so that the tests don't have this show. 

Not only is the easier to find unit test errors but stdout can be slow and the tests here run a little faster. 

```powershell

docker-compose run web bash -c 'export RAILS_ENV=test && rake db:test:prepare && rake test && rubocop'
Starting operationcodebackend_bundle_1             ... done
Starting operationcodebackend_operationcode-psql_1 ... done
Starting operationcodebackend_redis_1              ... done
Run options: --seed 61055

# Running:

......................................S.........................................................S..........................................................................................

Finished in 7.116397s, 26.2773 runs/s, 86.2796 assertions/s.
187 runs, 614 assertions, 0 failures, 0 errors, 2 skips

You have skipped tests. Run with --verbose for details.
Inspecting 251 files
...........................................................................................................................................................................................................................................................

251 files inspected, no offenses detected
```
2. Remove open and closed scope from the github statistic which can give warnings and confuse people.
3. Update gitignore to be okay with vscode
4. replace `before_filter` with `before_action` which was giving a deprecation warning. 