### PR TITLE
Move quickstart instructions into quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/cdnjs/cdnjs.svg)](https://github.com/OperationCode/operationcode_backend)
 
 
-[![Build Status](https://travis-ci.org/OperationCode/operationcode_backend.svg?branch=master)](https://travis-ci.org/OperationCode/operationcode_backend) 
+[![Build Status](https://travis-ci.org/OperationCode/operationcode_backend.svg?branch=master)](https://travis-ci.org/OperationCode/operationcode_backend)
 [![View performance data on Skylight](https://badges.skylight.io/status/0iQU6bEW8ha1.svg)](https://oss.skylight.io/app/applications/0iQU6bEW8ha1)
 [![Good First Issue](https://img.shields.io/github/issues/OperationCode/front-end/good%20first%20issue.svg)](https://github.com/OperationCode/operationcode_backend/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 
@@ -35,9 +35,6 @@ Please read our [Contributing Guide](CONTRIBUTING.md) to learn everything you ne
 
 **In continuing with the quick start instructions, it is assumed that you are no stranger to Rails Applications, and standard GitHub workflows such as forking, cloning, and branching.**
 
-## Description
-If you'd like to learn more about what this project is what a Backend is you can read about this in our [Introduction Guide](INTRODUCTION.md).
-
 Recommended versions of tools used within the repo:
 
 * Ruby: See [.ruby-version](https://github.com/OperationCode/operationcode_backend/blob/master/.ruby-version)
@@ -54,11 +51,9 @@ Recommended versions of tools used within the repo:
   <li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#git">git</a> </li>
     <li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#make-for-windows-only">make</a> </li>
     <li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#docker">docker</a> </li>
-  </ul> 
-     
-<li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#local-development-environment"> Retrieve Codebase</a> </li>
+  </ul>
 
-<li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#database-setup"> Retrieve Codebase</a> </li>
+<li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#local-development-environment"> Retrieve Codebase</a> </li>
 <li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#running-operationcode-backend"> Setup Codebase</a> </li>
 <li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#interact-with-backend"> Interact with Codebase</a> </li>
 
@@ -66,11 +61,14 @@ Recommended versions of tools used within the repo:
 
 </details >
 
+## Description
+If you'd like to learn more about what this project is what a Backend is you can read about this in our [Introduction Guide](INTRODUCTION.md).
+
 ## Wiki
 
 We also have a [wiki](https://github.com/OperationCode/operationcode_backend/wiki) that contains common tutorials, tips, workflows and documentation around how to successfully contribute to, and work within, the operationcode_backend repository.
 
-## Postmortem Reports 
+## Postmortem Reports
 
 <details>
 
@@ -79,7 +77,7 @@ We also have a [wiki](https://github.com/OperationCode/operationcode_backend/wik
 
 As incidents happen that require a great deal of troubleshooting and reveal a certain lack of domain knowledge, we wish to document these issues in way that can be used for contributors to learn. When such an event happens and a Root Cause Analysis is performed these issues will be added here.
 
-For the purpose of security we need to ensure that no data is added to AAR that would compromise any operation code asset. These reports are intended to document issues and reasoning for future contributors and assist future investigations. In these reports we keep the details blameless and focus on how we can improve and iterate in a better manner. 
+For the purpose of security we need to ensure that no data is added to AAR that would compromise any operation code asset. These reports are intended to document issues and reasoning for future contributors and assist future investigations. In these reports we keep the details blameless and focus on how we can improve and iterate in a better manner.
 
 <ol>
 <li> Slack User invites Stopped <a href="https://github.com/OperationCode/operationcode_backend/issues/388">link</a></li>

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Recommended versions of tools used within the repo:
   </ul>
 
 <li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#local-development-environment"> Retrieve Codebase</a> </li>
+<li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#database-setup"> Setup Database</a> </li>
 <li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#running-operationcode-backend"> Setup Codebase</a> </li>
 <li> <a href="https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md#interact-with-backend"> Interact with Codebase</a> </li>
 


### PR DESCRIPTION
Looks like the quickstart instructions in the README got separated from
the quickstart heading. This moves them back.

# Description of changes
Moves the quickstart instructions under the quickstart heading to make documentation clearer. Also removes a duplicate link in the instructions list.

# Issue Resolved
None
