### PR TITLE
Use COPY instead of ADD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ENV APP_HOME /app
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 
-ADD Gemfile $APP_HOME/
-ADD Gemfile.lock $APP_HOME/
+COPY Gemfile $APP_HOME/
+COPY Gemfile.lock $APP_HOME/
 
 ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
   BUNDLE_JOBS=2 \
@@ -16,6 +16,6 @@ ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
 
 RUN bundle install --system
 
-ADD . $APP_HOME/
+COPY . $APP_HOME/
 
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->

Hello,

The use of COPY is preferred over ADD when additional functionalities of ADD are not being used (like spraying the contents of a tar in a folder).

Ref:https://docs.docker.com/engine/articles/dockerfile_best-practices/#add-or-copy

Thanks.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
New issue.
