### PR TITLE
Add available scheme to CodeSchool url

### DIFF
--- a/app/models/code_school.rb
+++ b/app/models/code_school.rb
@@ -2,4 +2,22 @@ class CodeSchool < ApplicationRecord
   validates :name, :url, :logo, presence: true
   validates_inclusion_of :full_time, :hardware_included, :has_online, :online_only, :in => [true, false]
   has_many :locations, -> { order('state ASC, city ASC') }, dependent: :destroy
+
+  before_create :set_valid_scheme, :if => Proc.new{ |cs| URI(cs.url).scheme.nil? }
+
+  private
+
+  def set_valid_scheme
+    uri = URI::parse(self.url)
+    if uri.scheme.nil? && uri.host.nil?
+      unless uri.path.nil?
+        uri.scheme = "https"
+        uri.host = uri.path
+        uri.path = ""
+        HTTParty.get(uri.to_s, { timeout: 2 }).code rescue uri.scheme = "http"
+      end
+    end
+
+    self.url = uri.to_s
+  end
 end


### PR DESCRIPTION
# Description of changes
Before saving CodeSchool to the database, it takes the following steps:
1) Substitutes the protocol `http` in url without protocol
2) Make HTTP call to url with `https`
3) If `https` is not available, then change protocol to `http`

The http call slows down saving to the database. It can be avoided by using only the http protocol.
This is my first commit to an open source project, so please tell me what I am doing wrong if you can  :blush: 

# Issue Resolved
Fixes #436
