### PR TITLE
Only validate zip on create

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ApplicationRecord
 
   validates_format_of :email, :with => VALID_EMAIL
   validates :email, uniqueness: true
-  validates :zip, presence: true
+  validates :zip, presence: true, :on => :create
 
   has_many :requests
   has_many :votes

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -82,6 +82,22 @@ class UserTest < ActiveSupport::TestCase
     assert ["Zip can't be blank"], user.errors.full_messages
   end
 
+  test 'longitude and longitude are nil for nil zipcodes' do
+    Geocoder::Lookup::Test.add_stub('bad zip code', [{}])
+    u = build(:user, latitude: nil, longitude: nil, zip: nil)
+    u.update_attributes(zip: nil)
+    assert_nil u.latitude
+    assert_nil u.longitude
+  end
+
+  test 'longitude and longitude are nil for empty zipcodes' do
+    Geocoder::Lookup::Test.add_stub('bad zip code', [{}])
+    u = build(:user, latitude: nil, longitude: nil, zip: '')
+    u.update_attributes(zip: '')
+    assert_nil u.latitude
+    assert_nil u.longitude
+  end
+
   test 'longitude and longitude are nil for unknown zipcodes' do
     Geocoder::Lookup::Test.add_stub('bad zip code', [{}])
 


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
We only want to validate zip codes on creation as there are individuals who don't have zipcodes and wish to edit their account. 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes # Front end issue. 
