### PR TITLE
remove secret_key, in place of environment variable

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,16 +1,15 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-  
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  # Operation Code Comment: 
+  # Operation Code Comment:
   # We use "secret_key_base" as defined in "config/secrets.yml"
   # The development and test environments have the key publicly available
-  # Production environment has the key tied to kubernetes as setup in our 
+  # Production environment has the key tied to kubernetes as setup in our
   # infrastructure repo: https://github.com/OperationCode/operationcode_infra
-  #config.secret_key = 'No Overide Set'
+  # config.secret_key = 'No Overide Set'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,6 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-   config.secret_key = '34486348de8caa31dbf426f515084b3c4b33c15954ce1b0eb8f664f58eb68453ba7dd2603aa0a6a54ee816adcb5a72adca4564df5d772a7ae45ab1efbf814c9c'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,11 +1,16 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  # Devise will use the `secret_key_base` as its `secret_key`
-  # by default. You can change it below and use your own secret key.
+  # Operation Code Comment: 
+  # We use "secret_key_base" as defined in "config/secrets.yml"
+  # The development and test environments have the key publicly available
+  # Production environment has the key tied to kubernetes as setup in our 
+  # infrastructure repo: https://github.com/OperationCode/operationcode_infra
+  #config.secret_key = 'No Overide Set'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Devise config currently has `secret_key` set in the config, this overrides `secret_key_base` which is set in the environment variables. This removes the `secret_key` from the configs for clarity. 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #441 
