### PR TITLE
Postgres env secrets

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -36,4 +36,3 @@ production:
   <<: *default
   host: <%= ENV['POSTGRES_HOST'].present? ? ENV['POSTGRES_HOST'] : 'operationcode-psql-postgresql' %>
   database: operationcode_production
-  user: opcode_superuser

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,7 +22,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   user: <%= ENV['POSTGRES_USER'] %>
   host: <%= ENV['POSTGRES_HOST'] %>
-  password: <%= OperationCode.fetch_secret_with name: :postgres_password %>
+  password: <%= ENV['POSTGRES_PASSWORD'] %>
 
 development:
   <<: *default


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
This change should fix staging, instead of using harded username for production database we should be using the values listed in the kubernetes secrets which are namespaced. 


# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes Staging?

Summary:

Apparently both production and production-staging pods are using their own namespaced secrets storage. The secrets had a 2 values that were of importance:
`POSTGRES_HOST` and `POSTGRES_PASSWORD`

`POSTGRES_HOST` contained a different value, and in AWS it was shown that both of those exist and were paired correctly.

But in AWS the username for each was different and the k8s secrets showed they both used the same name as indicated in the config file.

Additionally they both used the same `POSTGRES_PASSWORD` but after inspecting our credentials management it was seen that prod and staging have two different master passwords. 

Prior to merging this I'm going to:
- [x] add POSTGRES_USER environment variable to each namespaced secrets store.
- [x] modify POSTGRES_PASSWORD in staging to use correct value
- [ ] deploy this codebase to staging and see if it fixes the issue.
- [ ] merge this to prod.  


I don't know how to do 3. Modifying 1 and 2 will not affect either environment until this is merged and changing 2 on staging isn't going to hurt us since until we merge this the username won't be valid. 

