### PR TITLE
🚧 WIP: add tests for the password forgot/reset/update endpoints

### DIFF
--- a/test/controllers/api/v1/users/passwords_controller_test.rb
+++ b/test/controllers/api/v1/users/passwords_controller_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class Api::V1::Users::PasswordsControllerTest < ActionDispatch::IntegrationTest
+  test 'forgot returns successful given an email of an existing user' do
+    create :user, email: 'forgetful@example.com'
+
+    post api_v1_users_passwords_forgot_url,
+         params: { email: 'forgetful@example.com' },
+         as: :json
+
+    assert_equal 200, response.status
+  end
+
+  test 'forgot generates a password reset token' do
+    user = create :user
+    User.any_instance.expects(:generate_password_token!)
+
+    post api_v1_users_passwords_forgot_url,
+         params: { email: user.email },
+         as: :json
+  end
+
+  test 'forgot emails user instructions to reset their password' do
+    user = create :user
+    User.any_instance.expects(:send_reset_password_instructions)
+
+    post api_v1_users_passwords_forgot_url,
+         params: { email: user.email },
+         as: :json
+  end
+
+  test 'forgot returns unprocessable error when given an email that does not match an existing user' do
+    post api_v1_users_passwords_forgot_url,
+         params: { email: 'totallydoesnotexist@example.com' },
+         as: :json
+
+    assert_equal 422, response.status
+  end
+
+  test 'forgot requires an email address be given' do
+    post api_v1_users_passwords_forgot_url,
+         params: { no: 'email key in params' },
+         as: :json
+    assert_equal 422, response.status
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -269,4 +269,16 @@ class UserTest < ActiveSupport::TestCase
     assert create(:user, military_status: nil).valid?
     refute User.new(military_status: 'spaghetti monster').valid?
   end
+
+  test 'generate_password_token! does what it says' do
+    user = create :user
+    assert_nil user.reset_password_token
+    assert_nil user.reset_password_sent_at
+
+    user.generate_password_token!
+
+    user.reload
+    assert_not_nil user.reset_password_token
+    assert_not_nil user.reset_password_sent_at
+  end
 end


### PR DESCRIPTION
Work in progress. Not ready for merge.

# Description of changes

* controller test for forgot and model test for the generate_password_token! method that forgot uses

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #
