### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.3.3
 
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs graphviz
 
 ENV APP_HOME /app


### PR DESCRIPTION
During the **Database setup:** of the Docker Setup (https://github.com/OperationCode/operationcode_backend/blob/master/docs/setup/docker_setup.md) I encountered an error in second step of Dockerfile (`make setup`). I then used the following to rectify the issue: https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease?newreg=ebb41cc90fe14d52a0e83393a2a90918
This updated the sources.list and allowed the container to run `apt-get update` without fail. Submitted PR since I don't think this will break anything critical in the code.

# Description of changes
Added an additional line to the Dockerfile that updates the Debian `/etc/apt/sources.list` of the container for ruby2.3.3.

# Issue Resolved
No issue opened for this. 
Fixes #

