### PR TITLE
Add bundle prefix to sidekiq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   sidekiq:
     image: operationcodebackend_web
-    command: sidekiq -C config/sidekiq.yml.erb
+    command: bundle exec sidekiq -C config/sidekiq.yml.erb
     volumes:
       - .:/app
     volumes_from:


### PR DESCRIPTION
# Description of changes

Resolves an error generated when running `make test`.

Error:

```
ERROR: for operationcodebackend_sidekiq_1  Cannot start service sidekiq: b'OCI runtime create failed: container_linux.go:344: starting container process caused "exec: \\"sidekiq\\": executable file not found in $PATH": unknown'
```

# Issue Resolved

No related ticket, this was an issue picked up in the slack chat