### PR TITLE
Add bundle prefixes to rails/rake/rubocop commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,34 +3,34 @@ DOCKER := docker
 DOCKER_COMPOSE := docker-compose
 
 .PHONY: all
-all: run 
+all: run
 
 .PHONY:  nuke
-nuke: 
+nuke:
 	${DOCKER} system prune -a --volumes
 
-.PHONY: minty-fresh 
-minty-fresh: 
+.PHONY: minty-fresh
+minty-fresh:
 	${DOCKER_COMPOSE} down --rmi all --volumes
 
 .PHONY: rmi
-rmi: 
+rmi:
 	${DOCKER} images -q | xargs docker rmi -f
 
 .PHONY: rmdi
-rmdi: 
+rmdi:
 	${DOCKER} images -a --filter=dangling=true -q | xargs ${DOCKER} rmi
 
 .PHONY: rm-exited-containers
-rm-exited-containers: 
-	${DOCKER} ps -a -q -f status=exited | xargs ${DOCKER} rm -v 
+rm-exited-containers:
+	${DOCKER} ps -a -q -f status=exited | xargs ${DOCKER} rm -v
 
 .PHONY: fresh-restart
 fresh-restart: minty-fresh setup test run
 
 .PHONY: console-sandbox
 console-sandbox:
-	docker-compose run ${RAILS_CONTAINER} rails console --sandbox
+	docker-compose run ${RAILS_CONTAINER} bundle exec rails console --sandbox
 
 .PHONY: run
 run:
@@ -50,44 +50,44 @@ build:
 
 .PHONY: console
 console:
-	docker-compose run ${RAILS_CONTAINER} rails console
+	docker-compose run ${RAILS_CONTAINER} bundle exec rails console
 
 .PHONY: routes
 routes:
-	docker-compose run ${RAILS_CONTAINER} rake routes
+	docker-compose run ${RAILS_CONTAINER} bundle exec rake routes
 
 .PHONY: db_create
 db_create:
-	docker-compose run ${RAILS_CONTAINER} rake db:create
+	docker-compose run ${RAILS_CONTAINER} bundle exec rake db:create
 
 .PHONY: db_migrate
 db_migrate:
-	docker-compose run ${RAILS_CONTAINER} rake db:migrate
+	docker-compose run ${RAILS_CONTAINER} bundle exec rake db:migrate
 
 .PHONY: db_status
 db_status:
-	docker-compose run ${RAILS_CONTAINER} rake db:migrate:status
+	docker-compose run ${RAILS_CONTAINER} bundle exec rake db:migrate:status
 
 .PHONY: db_rollback
 db_rollback:
-	docker-compose run ${RAILS_CONTAINER} rake db:rollback
+	docker-compose run ${RAILS_CONTAINER} bundle exec rake db:rollback
 
 .PHONY: db_seed
 db_seed:
-	docker-compose run ${RAILS_CONTAINER} rake db:seed
+	docker-compose run ${RAILS_CONTAINER} bundle exec rake db:seed
 
 .PHONY: test
 test: bg
 	docker-compose run operationcode-psql bash -c "while ! psql --host=operationcode-psql --username=postgres -c 'SELECT 1'; do sleep 5; done;"
-	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && rake db:test:prepare && rake test && rubocop'
+	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && bundle exec rake db:test:prepare && bundle exec rake test && rubocop'
 
 .PHONY: rubocop
 rubocop:
-	docker-compose run ${RAILS_CONTAINER} rubocop
+	docker-compose run ${RAILS_CONTAINER} bundle exec rubocop
 
 .PHONY: rubocop_auto_correct
 rubocop_auto_correct:
-	docker-compose run ${RAILS_CONTAINER} rubocop -a --auto-correct
+	docker-compose run ${RAILS_CONTAINER} bundle exec rubocop -a --auto-correct
 
 .PHONY: bundle
 bundle:


### PR DESCRIPTION
# Description of changes

We're isolated in the docker containers so we _shouldn't_ run into conflicts here, but this closely reflects the commands as you'd want to run them locally, if you weren't using a Makefile. So, I'd consider it more a "documentation" fix than anything

Also cleaned up some trailing empty spaces on commands. 

This might be considered a style/preference but I consider it more of a good rule to follow when using bundler. Please feel free to close it if it doesn't add any value.

# Issue Resolved

No issues closed. This is a general documentation/cleanup suggestion