### PR TITLE
Install version of bundler from Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
   BUNDLE_JOBS=2 \
   BUNDLE_PATH=/bundle
 
-RUN bundle install --system
+RUN gem update --system && \
+  gem install bundler --no-document --version $(tail -n 1 Gemfile.lock) | sed -e 's/^[[:space:]]*//' && \
+  bundle install --system
 
 COPY . $APP_HOME/
 


### PR DESCRIPTION
# Description of changes

Uses built-in system tools to parse the Gemfile.lock & pull out the
bundler version used to build the Gemfile.lock, ensuring that's the same
version of bundler used to bundle inside the container

- Resolves the warning:
> Warning: the running version of Bundler (1.14.6) is older than the version that created the lockfile (1.17.1). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`."
- Helps prevent issues with bundle version conflicts/differences in
the future
- Updates rubygems to ensure we have all the latest patches and
updates. Per the output from inside the container, this includes a
number of patches dating back to 2017-03-16 which include at least five
(5) CVE fixes

# Issue Resolved

No related ticket. This was noted while going thru the backend setup documentation