### PR TITLE
Revert "Update to Ruby 2.6.3"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:2.6.3
+FROM ruby:2.3.3
 
-RUN printf "deb http://deb.debian.org/debian/ stretch main\ndeb-src http://deb.debian.org/debian/ stretch main\ndeb http://security.debian.org stretch/updates main\ndeb-src http://security.debian.org stretch/updates main" > /etc/apt/sources.list
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs graphviz
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ db_seed:
 .PHONY: test
 test: bg
 	docker-compose run operationcode-psql bash -c "while ! psql --host=operationcode-psql --username=postgres -c 'SELECT 1'; do sleep 5; done;"
-	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && bundle exec rake db:test:prepare && bundle exec rake test && bundle exec rubocop'
+	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && bundle exec rake db:test:prepare && bundle exec rake test && rubocop'
 
 .PHONY: rubocop
 rubocop:

--- a/lib/tasks/schools_from_yml.rake
+++ b/lib/tasks/schools_from_yml.rake
@@ -1,7 +1,7 @@
 namespace :schools do
   desc 'Reads from the ./config/code_schools.yml and creates records in the database.'
   task populate: :environment do
-    schools = YAML::load_file(File.join('./config', 'code_schools.yml'))
+    schools = YAML::load_file(File.join('./config', 'code_schools.yml'), 'r')
     schools.each do |school|
       begin
         object = CodeSchool.create!(


### PR DESCRIPTION
Reverts OperationCode/operationcode_backend#500

This is failing in k8s due to missing sidekiq exectuable. We rolled back manually in k8s. 