### PR TITLE
Https code school url validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,3 +302,5 @@ dump.rdb
 
 # Model Graph image generated
 docs/models/model_graph.png
+.vscode
+OpCodeBackEnd.code-workspace

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,12 @@ db_seed:
 .PHONY: test
 test: bg
 	docker-compose run operationcode-psql bash -c "while ! psql --host=operationcode-psql --username=postgres -c 'SELECT 1'; do sleep 5; done;"
-	docker-compose run ${RAILS_CONTAINER} bash -c 'export RAILS_ENV=test && bundle exec rake db:test:prepare && bundle exec rake test && bundle exec rubocop'
+	docker-compose run ${RAILS_CONTAINER} bash -xc 'export RAILS_ENV=test && bundle exec rake db:test:prepare && bundle exec rake test && bundle exec rubocop'
+	# change the appropriate portion of above to enable verbose test output
+	# bundle exec rake test TESTOPTS='-v'
+	#
+	# This one allows you to run one test file at a time by changing the file path to a specific test file
+	# bundle exec rake test TEST=test/controllers/api/v1/code_schools_controller_test.rb TESTOPTS='-v'
 
 .PHONY: rubocop
 rubocop:

--- a/app/models/code_school.rb
+++ b/app/models/code_school.rb
@@ -1,5 +1,6 @@
 class CodeSchool < ApplicationRecord
-  validates :name, :url, :logo, presence: true
+  validates :name, :logo, presence: true
+  validates :url, presence: true, format: { with: /\Ahttps:\/\/(.*)/i, message: "URL must be HTTPS, if unable please secure your site" }
   validates_inclusion_of :full_time, :hardware_included, :has_online, :online_only, :in => [true, false]
   has_many :locations, -> { order('state ASC, city ASC') }, dependent: :destroy
 end

--- a/app/models/code_school.rb
+++ b/app/models/code_school.rb
@@ -1,6 +1,6 @@
 class CodeSchool < ApplicationRecord
-  validates :name, :logo, presence: true
-  validates :url, presence: true, format: { with: /\Ahttps:\/\/(.*)/i, message: "URL must be HTTPS, if unable please secure your site" }
+  validates :name, :logo, :url, presence: true
+  validates :url, presence: true, format: { with: %r{\Ahttps://(.*)}, message: 'must be HTTPS, if unable please secure your site' }
   validates_inclusion_of :full_time, :hardware_included, :has_online, :online_only, :in => [true, false]
   has_many :locations, -> { order('state ASC, city ASC') }, dependent: :destroy
 end

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -29,7 +29,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     assert errors.include? "Url can't be blank"
   end
 
-  test ":validates CodeSchool uses HTTPS for URL" do
+  test ':validates CodeSchool uses HTTPS for URL' do
     params = {
       code_school: {
         name: '1337School',
@@ -42,7 +42,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
       as: :json
 
     errors = JSON.parse(response.body)['errors']
-    assert errors.include? "URL must be HTTPS, if unable please secure your site"
+    assert errors.include? 'Url must be HTTPS, if unable please secure your site'
   end
 
   test ':index endpoint returns a JSON list of all CodeSchools' do

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -29,6 +29,22 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
     assert errors.include? "Url can't be blank"
   end
 
+  test ":validates CodeSchool uses HTTPS for URL" do
+    params = {
+      code_school: {
+        name: '1337School',
+        url: 'http://31337codeschool.com'
+      }
+    }
+    post api_v1_code_schools_url,
+      params: params,
+      headers: @headers,
+      as: :json
+
+    errors = JSON.parse(response.body)['errors']
+    assert errors.include? "Url must be https"
+  end
+
   test ':index endpoint returns a JSON list of all CodeSchools' do
     get api_v1_code_schools_path, as: :json
 

--- a/test/controllers/api/v1/code_schools_controller_test.rb
+++ b/test/controllers/api/v1/code_schools_controller_test.rb
@@ -42,7 +42,7 @@ class Api::V1::CodeSchoolsControllerTest < ActionDispatch::IntegrationTest
       as: :json
 
     errors = JSON.parse(response.body)['errors']
-    assert errors.include? "Url must be https"
+    assert errors.include? "URL must be HTTPS, if unable please secure your site"
   end
 
   test ':index endpoint returns a JSON list of all CodeSchools' do

--- a/test/factories/code_schools.rb
+++ b/test/factories/code_schools.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :code_school do
     name { Faker::Company.name }
-    url { Faker::Internet.url }
+    url { Faker::Internet.url(Faker::Internet.domain_name, '', 'https') }
     logo { Faker::Internet.url }
     full_time { Faker::Boolean.boolean }
     hardware_included { Faker::Boolean.boolean }


### PR DESCRIPTION
# Description of changes
Small change to the Makefile with comments that can help anyone debugging to output verbose tests or test just one when running `make test`

Updated the `code_school.rb` model to have URL validation for HTTPS. Uses Regex to accomplish this. 
Added a test to ensure that it will throw an error when a HTTP address is given.
Updated the Code School Factory Faker for URL to generate HTTPS urls for mock data in testing

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #436 
