### PR TITLE
Added housing_provided column to locations table, defaulting to false

### DIFF
--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -1,3 +1,3 @@
 class LocationSerializer < ActiveModel::Serializer
-  attributes :va_accepted, :address1, :address2, :city, :state, :zip
+  attributes :va_accepted, :address1, :address2, :city, :state, :zip, :provides_housing
 end

--- a/db/migrate/20191005191332_add_provides_housing_to_location.rb
+++ b/db/migrate/20191005191332_add_provides_housing_to_location.rb
@@ -1,0 +1,5 @@
+class AddProvidesHousingToLocation < ActiveRecord::Migration[5.0]
+  def change
+    add_column :locations, :provides_housing, :boolean, :default => false
+  end
+end


### PR DESCRIPTION
# Description of changes
Created a new migration to add a housing_provided column to the locations table, with a default value of false. Also added housing_provided to the locations serializer so that it is rendered in the JSON returned from the API.

This commit is meant to solve issue #397. It will allow housing data to be stored in the back end for each location.

# Issue Resolved
Fixes #397 
